### PR TITLE
Minor fix

### DIFF
--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1001,7 +1001,7 @@ _raqm_resolve_scripts (raqm_t *rq)
   for (size_t i = 0; i < rq->text_len; ++i)
   {
     SCRIPT_TO_STRING (rq->scripts[i]);
-    RAQM_TEST ("script for ch[%ld]\t%s\n", i, buff);
+    RAQM_TEST ("script for ch[%zu]\t%s\n", i, buff);
   }
   RAQM_TEST ("\n");
 #endif
@@ -1074,7 +1074,7 @@ _raqm_resolve_scripts (raqm_t *rq)
   for (size_t i = 0; i < rq->text_len; ++i)
   {
     SCRIPT_TO_STRING (rq->scripts[i]);
-    RAQM_TEST ("script for ch[%ld]\t%s\n", i, buff);
+    RAQM_TEST ("script for ch[%zu]\t%s\n", i, buff);
   }
   RAQM_TEST ("\n");
 #endif


### PR DESCRIPTION
Change `%ld` to `%zu`,  so that on 32-bit machine it does not complain about  how it expects type of long int and not size_t. 