### PR TITLE
Line breaking support 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,9 @@ libraqm_la_SOURCES = \
     raqm.h \
     reorder_runs.c \
     reorder_runs.h \
+    ucdn/ucdn.h \
+    ucdn/ucdn.c \
+    ucdn/unicodedata_db.h \
     $(NULL)
 
 include_HEADERS = \

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -31,6 +31,8 @@
 #include <hb.h>
 #include <hb-ft.h>
 
+#include <ucdn.h>
+
 #include "raqm.h"
 #include "reorder_runs.h"
 
@@ -188,11 +190,15 @@ struct _raqm {
   raqm_glyph_t    *glyphs;
 
   raqm_flags_t     flags;
+
+  int              line_width;
+  raqm_alignment_t alignment;
 };
 
 struct _raqm_run {
   int            pos;
   int            len;
+  int			 line;
 
   hb_direction_t direction;
   hb_script_t    script;
@@ -242,6 +248,10 @@ raqm_create (void)
   rq->glyphs = NULL;
 
   rq->flags = RAQM_FLAG_NONE;
+
+  rq->line_width = 2147483647;
+
+  rq->alignment = RAQM_ALIGNMENT_LEFT;
 
   return rq;
 }
@@ -570,11 +580,61 @@ raqm_set_freetype_face_range (raqm_t *rq,
   return true;
 }
 
+/**
+ * raqm_set_line_width:
+ * @rq: a #raqm_t.
+ * @width: the line width.
+ *
+ * Sets the maximum line width for the paragraph, so that when the width is
+ * exceeded, a breaking line mechanism is applied.
+ *
+ * Return value:
+ * %true if no errors happened, %false otherwise.
+ *
+ * Since: 0.2
+ */
+bool
+raqm_set_line_width (raqm_t *rq, int width)
+{
+  if (!rq)
+    return false;
+
+  rq->line_width = width;
+
+  return true;
+}
+
+/**
+ * raqm_set_paragraph_alignment:
+ * @rq: a #raqm_t.
+ * @alignment: paragraph alignment.
+ *
+ * Sets the paragraph alignment.
+ *
+ * Return value:
+ * %true if no errors happened, %false otherwise.
+ *
+ * Since: 0.2
+ */
+bool
+raqm_set_paragraph_alignment (raqm_t *rq, raqm_alignment_t alignment)
+{
+  if (!rq)
+    return false;
+
+  rq->alignment = alignment;
+
+  return true;
+}
+
 static bool
 _raqm_itemize (raqm_t *rq);
 
 static bool
 _raqm_shape (raqm_t *rq);
+
+static bool
+_raqm_line_break (raqm_t *rq);
 
 /**
  * raqm_layout:
@@ -606,6 +666,9 @@ raqm_layout (raqm_t *rq)
 
   if (!_raqm_shape (rq))
     return false;
+
+  if (!_raqm_line_break (rq))
+	return false;
 
   return true;
 }
@@ -647,10 +710,6 @@ raqm_get_glyphs (raqm_t *rq,
 
   *length = count;
 
-  if (rq->glyphs)
-    free (rq->glyphs);
-
-  rq->glyphs = malloc (sizeof (raqm_glyph_t) * count);
   if (!rq->glyphs)
   {
     *length = 0;
@@ -659,34 +718,14 @@ raqm_get_glyphs (raqm_t *rq,
 
   RAQM_TEST ("Glyph information:\n");
 
-  count = 0;
-  for (raqm_run_t *run = rq->runs; run != NULL; run = run->next)
+  for (size_t i = 0; i < *length; i++)
   {
-    size_t len;
-    hb_glyph_info_t *info;
-    hb_glyph_position_t *position;
-
-    len = hb_buffer_get_length (run->buffer);
-    info = hb_buffer_get_glyph_infos (run->buffer, NULL);
-    position = hb_buffer_get_glyph_positions (run->buffer, NULL);
-
-    for (size_t i = 0; i < len; i++)
-    {
-      rq->glyphs[count + i].index = info[i].codepoint;
-      rq->glyphs[count + i].cluster = info[i].cluster;
-      rq->glyphs[count + i].x_advance = position[i].x_advance;
-      rq->glyphs[count + i].y_advance = position[i].y_advance;
-      rq->glyphs[count + i].x_offset = position[i].x_offset;
-      rq->glyphs[count + i].y_offset = position[i].y_offset;
-      rq->glyphs[count + i].ftface = rq->ftfaces[rq->glyphs[count + i].cluster];
-
-      RAQM_TEST ("glyph [%d]\tx_offset: %d\ty_offset: %d\tx_advance: %d\tfont: %s\n",
-          rq->glyphs[count + i].index, rq->glyphs[count + i].x_offset,
-          rq->glyphs[count + i].y_offset, rq->glyphs[count + i].x_advance,
-          rq->glyphs[count + i].ftface->family_name);
-    }
-
-    count += len;
+      RAQM_TEST ("glyph [%d]\tx_offset: %d\ty_offset: %d\tx_advance: %d\tx_position:"
+                 " %d\ty_position: %d\tfont: %s\n",
+                 rq->glyphs[i].index, rq->glyphs[i].x_offset,
+                 rq->glyphs[i].y_offset, rq->glyphs[i].x_advance,
+                 rq->glyphs[i].x_position, rq->glyphs[i].y_position,
+                 rq->glyphs[i].ftface->family_name);
   }
 
   if (rq->flags & RAQM_FLAG_UTF8)
@@ -698,9 +737,9 @@ raqm_get_glyphs (raqm_t *rq,
     RAQM_TEST ("\n");
 #endif
 
-    for (size_t i = 0; i < count; i++)
-      rq->glyphs[i].cluster = _raqm_u32_to_u8_index (rq,
-                                                     rq->glyphs[i].cluster);
+	for (size_t i = 0; i < count; i++)
+	  rq->glyphs[i].cluster = _raqm_u32_to_u8_index (rq,
+													   rq->glyphs[i].cluster);
 
 #ifdef RAQM_TESTING
     RAQM_TEST ("UTF-8 clusters: ");
@@ -726,6 +765,397 @@ _raqm_hb_dir (raqm_t *rq, FriBidiLevel level)
       dir = HB_DIRECTION_RTL;
 
   return dir;
+}
+
+enum break_class
+{
+	// input types
+	OP = 0,	// open
+	CL,	// closing punctuation
+	CP,	// closing parentheses (from 5.2.0) (before 5.2.0 treat like CL)
+	QU,	// quotation
+	GL,	// glue
+	NS,	// no-start
+	EX,	// exclamation/interrogation
+	SY,	// Syntax (slash)
+	IS,	// infix (numeric) separator
+	PR,	// prefix
+	PO,	// postfix
+	NU,	// numeric
+	AL,	// alphabetic
+	ID,	// ideograph (atomic)
+	IN,	// inseparable
+	HY,	// hyphen
+	BA,	// break after
+	BB,	// break before
+	B2,	// break both
+	ZW,	// ZW space
+	CM,	// combining mark
+	WJ, // word joiner
+
+	// used for Korean Syllable Block pair table
+	H2, // Hamgul 2 Jamo Syllable
+	H3, // Hangul 3 Jamo Syllable
+	JL, // Jamo leading consonant
+	JV, // Jamo vowel
+	JT, // Jamo trailing consonant
+
+	// these are not handled in the pair tables
+	SA, // South (East) Asian
+	SP,	// space
+	PS,	// paragraph and line separators
+	BK,	// hard break (newline)
+	CR, // carriage return
+	LF, // line feed
+	NL, // next line
+	CB, // contingent break opportunity
+	SG, // surrogate
+	AI, // ambiguous
+	XX, // unknown
+};
+
+// Define some short-cuts for the table
+#define oo DIRECT_BREAK				// '_' break allowed
+#define SS INDIRECT_BREAK				// '%' only break across space (aka 'indirect break' below)
+#define cc COMBINING_INDIRECT_BREAK	// '#' indirect break for combining marks
+#define CC COMBINING_PROHIBITED_BREAK	// '@' indirect break for combining marks
+#define XX PROHIBITED_BREAK			// '^' no break allowed_BRK
+
+enum break_action {
+        DIRECT_BREAK = 0,             	// _ in table, 	oo in array
+        INDIRECT_BREAK,               	// % in table, 	SS in array
+        COMBINING_INDIRECT_BREAK,		// # in table, 	cc in array
+        COMBINING_PROHIBITED_BREAK,  	// @ in table 	CC in array
+        PROHIBITED_BREAK,             	// ^ in table, 	XX in array
+};
+
+static bool *
+_raqm_find_line_break (raqm_t *rq)
+{
+	size_t length = rq->text_len;
+	enum break_class   current_class;
+	enum break_class   next_class;
+	enum break_action *break_actions;
+	enum break_action  current_action;
+	bool *break_here;
+
+	enum break_action  break_pairs[][JT+1] =  {
+		//       1   2   3   4	5	6	7	8	9  10  11  12  13  14  15  16  17  18  19  20  21   22  23  24  25  26  27
+		//     OP, CL, CL, QU, GL, NS, EX, SY, IS, PR, PO, NU, AL, ID, IN, HY, BA, BB, B2, ZW, CM, WJ,  H2, H3, JL, JV, JT, = after class
+		/*OP*/ { XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, CC, XX, XX, XX, XX, XX, XX }, // OP open
+		/*CL*/ { oo, XX, XX, SS, SS, XX, XX, XX, XX, SS, SS, oo, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // CL close
+		/*CP*/ { oo, XX, XX, SS, SS, XX, XX, XX, XX, SS, SS, SS, SS, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // CL close
+		/*QU*/ { XX, XX, XX, SS, SS, SS, XX, XX, XX, SS, SS, SS, SS, SS, SS, SS, SS, SS, SS, XX, cc, XX, SS, SS, SS, SS, SS }, // QU quotation
+		/*GL*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, SS, SS, SS, SS, SS, SS, SS, SS, SS, SS, XX, cc, XX, SS, SS, SS, SS, SS }, // GL glue
+		/*NS*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, oo, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // NS no-start
+		/*EX*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, oo, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // EX exclamation/interrogation
+		/*SY*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // SY Syntax (slash)
+		/*IS*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, SS, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // IS infix (numeric) separator
+		/*PR*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, SS, SS, oo, SS, SS, oo, oo, XX, cc, XX, SS, SS, SS, SS, SS }, // PR prefix
+		/*PO*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, SS, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // NU numeric
+		/*NU*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, SS, SS, SS, SS, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // AL alphabetic
+		/*AL*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, SS, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // AL alphabetic
+		/*ID*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // ID ideograph (atomic)
+		/*IN*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // IN inseparable
+		/*HY*/ { oo, XX, XX, SS, oo, SS, XX, XX, XX, oo, oo, SS, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // HY hyphens and spaces
+		/*BA*/ { oo, XX, XX, SS, oo, SS, XX, XX, XX, oo, oo, oo, oo, oo, oo, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // BA break after
+		/*BB*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, SS, SS, SS, SS, SS, SS, SS, SS, SS, SS, XX, cc, XX, SS, SS, SS, SS, SS }, // BB break before
+		/*B2*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, oo, oo, oo, oo, SS, SS, oo, XX, XX, cc, XX, oo, oo, oo, oo, oo }, // B2 break either side, but not pair
+		/*ZW*/ { oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, oo, XX, oo, oo, oo, oo, oo, oo, oo }, // ZW zero width space
+		/*CM*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, oo, SS, SS, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, oo }, // CM combining mark
+		/*WJ*/ { SS, XX, XX, SS, SS, SS, XX, XX, XX, SS, SS, SS, SS, SS, SS, SS, SS, SS, SS, XX, cc, XX, SS, SS, SS, SS, SS }, // WJ word joiner
+		/*H2*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, SS, SS }, // Hangul 2 Jamo syllable
+		/*H3*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, SS }, // Hangul 3 Jamo syllable
+		/*JL*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, SS, SS, SS, SS, oo }, // Jamo Leading Consonant
+		/*JV*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, SS, SS }, // Jamo Vowel
+		/*JT*/ { oo, XX, XX, SS, SS, SS, XX, XX, XX, oo, SS, oo, oo, oo, SS, SS, SS, oo, oo, XX, cc, XX, oo, oo, oo, oo, SS }, // Jamo Trailing Consonant
+	};
+
+	break_actions = malloc (sizeof (enum break_action) * length);
+	break_here = malloc (sizeof (bool) * length);
+
+	current_class = ucdn_get_resolved_linebreak_class(rq->text[0]);
+	next_class    = ucdn_get_resolved_linebreak_class(rq->text[1]);
+
+	// handle case where input starts with an LF
+	if (current_class == LF)
+		current_class = BK;
+
+	// treat NL like BK
+	if (current_class == NL)
+		current_class = BK;
+
+	// treat SP at start of input as if it followed WJ
+	if (current_class == SP)
+		current_class = WJ;
+
+	// loop over all pairs in the string up to a hard break or CRLF pair
+	for (size_t i = 1; (i < length) && (current_class != BK) && (current_class != CR || next_class == LF); i++)
+	{
+		next_class = ucdn_get_resolved_linebreak_class(rq->text[i]);
+
+		// handle spaces explicitly
+		if (next_class == SP) {
+                        break_actions[i-1]  = PROHIBITED_BREAK;   // apply rule LB 7: � SP
+			continue;
+		}
+
+		if (next_class == BK || next_class == NL || next_class == LF) {
+                        break_actions[i-1]  = PROHIBITED_BREAK;
+			current_class = BK;
+			continue;
+		}
+
+		if (next_class == CR)
+		{
+                        break_actions[i-1]  = PROHIBITED_BREAK;
+			current_class = CR;
+			continue;
+		}
+
+		// lookup pair table information in brkPairs[before, after];
+		current_action = break_pairs[current_class][next_class];
+		break_actions[i-1] = current_action;
+
+                if (current_action == INDIRECT_BREAK)		// resolve indirect break
+		{
+			if (ucdn_get_resolved_linebreak_class(rq->text[i-1]) == SP)                    // if context is A SP * B
+                                break_actions[i-1] = INDIRECT_BREAK;             //       break opportunity
+			else                                        // else
+                                break_actions[i-1] = PROHIBITED_BREAK;           //       no break opportunity
+		}
+
+                else if (current_action == COMBINING_PROHIBITED_BREAK)		// this is the case OP SP* CM
+		{
+                        break_actions[i-1] = COMBINING_PROHIBITED_BREAK;     // no break allowed
+			if (ucdn_get_resolved_linebreak_class(rq->text[i-1]) != SP)
+				continue;                               // apply rule 9: X CM* -> X
+		}
+
+                else if (current_action == COMBINING_INDIRECT_BREAK)		// resolve combining mark break
+		{
+                        break_actions[i-1] = PROHIBITED_BREAK;               // don't break before CM
+			if (ucdn_get_resolved_linebreak_class(rq->text[i-1]) == SP)
+			{
+                                break_actions[i-1] = PROHIBITED_BREAK;		// legacy: keep SP CM together
+				if (i > 1)
+                                        break_actions[i-2] = ((ucdn_get_resolved_linebreak_class(rq->text[i-2]) == SP) ? INDIRECT_BREAK : DIRECT_BREAK);
+			} else                                     // apply rule 9: X CM * -> X
+				continue;
+		}
+
+		current_class = next_class;
+	}
+
+	for(size_t i = 0; i < length; i++)
+	{
+                if (break_actions[i] == INDIRECT_BREAK || break_actions[i] == DIRECT_BREAK )
+		{
+			break_here[i] = true;
+		}
+		else
+			break_here[i] = false;
+	}
+
+	free (break_actions);
+	return break_here;
+}
+
+static int
+_raqm_logical_sort(const void *a,const void *b)
+{
+    raqm_glyph_t *ia = (raqm_glyph_t *)a;
+    raqm_glyph_t *ib = (raqm_glyph_t *)b;
+
+return ia->cluster - ib->cluster;
+}
+
+static int
+_raqm_visual_sort(const void *a,const void *b)
+{
+    raqm_glyph_t *ia = (raqm_glyph_t *)a;
+    raqm_glyph_t *ib = (raqm_glyph_t *)b;
+
+    if (ia->line == ib->line)
+    {
+        return ia->visual_index - ib->visual_index;
+    }
+
+    else
+    {
+        return ia->line - ib->line;
+    }
+}
+
+static bool
+_raqm_line_break (raqm_t *rq)
+{
+    int count = 0;
+    int glyphs_length = 0;
+    int current_x = 0;
+    int line_space;
+    int current_line = 0;
+    int align_offset = 0;
+
+    int i = 0;
+    int j = 0;
+    int k = 0;
+
+    int space_count = 0;
+    int space_extension;
+
+    bool *break_here = NULL;
+
+    /* finding possible breaks in text */
+    break_here = _raqm_find_line_break(rq);
+
+    /* counting total glyphs */
+    for (raqm_run_t *run = rq->runs; run != NULL; run = run->next)
+      count += hb_buffer_get_length (run->buffer);
+
+    glyphs_length = count;
+
+    rq->glyphs = malloc (sizeof (raqm_glyph_t) * count);
+    if (!rq->glyphs)
+    {
+      return false;
+    }
+
+    /* populating glyphs */
+    count = 0;
+    for (raqm_run_t *run = rq->runs; run != NULL; run = run->next)
+    {
+      size_t len;
+      hb_glyph_info_t *info;
+      hb_glyph_position_t *position;
+
+      len = hb_buffer_get_length (run->buffer);
+      info = hb_buffer_get_glyph_infos (run->buffer, NULL);
+      position = hb_buffer_get_glyph_positions (run->buffer, NULL);
+
+          for (i = 0; i < (int)len; i++)
+          {
+              rq->glyphs[count + i].index = info[i].codepoint;
+              rq->glyphs[count + i].cluster = info[i].cluster;
+              rq->glyphs[count + i].x_advance = position[i].x_advance;
+              rq->glyphs[count + i].y_advance = position[i].y_advance;
+              rq->glyphs[count + i].x_offset = position[i].x_offset;
+              rq->glyphs[count + i].y_offset = position[i].y_offset;
+              rq->glyphs[count + i].ftface = rq->ftfaces[rq->glyphs[count + i].cluster];
+              rq->glyphs[count + i].visual_index = count + i;
+              rq->glyphs[count + i].line = 0;
+          }
+
+      count += len;
+    }
+
+    /* Sorting glyphs to logical order */
+    qsort(rq->glyphs, glyphs_length, sizeof(raqm_glyph_t), _raqm_logical_sort);
+
+    /* Line breaking */
+    current_x = 0;
+    current_line = 0;
+    for (i = 0; i < glyphs_length; i++)
+    {
+        rq->glyphs[i].line = current_line;
+        current_x += rq->glyphs[i].x_offset + rq->glyphs[i].x_advance;
+
+        if (current_x > rq->line_width)
+        {
+            while (!break_here[rq->glyphs[i].cluster] && i >= 0)
+            {
+                i--;
+            }
+
+            /* Next line cannot start with a white space */
+            if (rq->text[rq->glyphs[i + 1].cluster] == 32)
+            {
+                for (j = i + 1; rq->text[rq->glyphs[j].cluster] == 32; j++)
+                {
+                    rq->glyphs[j].line = current_line;
+                }
+                i = j - 1; //skip those
+            }
+
+            /* Handeling glyphs for the same character */
+            if (rq->glyphs[i + 1].cluster == rq->glyphs[i].cluster)
+            {
+                for (k = i + 1; rq->glyphs[k].cluster == rq->glyphs[i].cluster; k++)
+                {
+                    rq->glyphs[j].line = current_line;
+                }
+                i = k - 1; //skip those
+            }
+
+            current_line ++;
+            current_x = 0;
+        }
+    }
+
+    /* Sorting glyphs back to visual order */
+    qsort(rq->glyphs, glyphs_length, sizeof(raqm_glyph_t), _raqm_visual_sort);
+
+    /* calculating positions */
+    current_line = 0;
+    current_x = 0;
+    for (i = 0; i < glyphs_length; i++)
+    {
+        line_space =  (-1) * (rq->ftfaces[rq->glyphs[i].cluster]->ascender + abs(rq->ftfaces[rq->glyphs[i].cluster]->descender));
+
+        if (rq->glyphs[i].line != current_line)
+        {   
+            current_x = 0;
+            current_line = rq->glyphs[i].line;
+        }
+
+        rq->glyphs[i].x_position = current_x + rq->glyphs[i].x_offset;
+        rq->glyphs[i].y_position = rq->glyphs[i].y_offset + rq->glyphs[i].line * line_space;
+
+        current_x += rq->glyphs[i].x_advance;
+    }
+
+    /* handeling alighnment */
+    if (rq->alignment != RAQM_ALIGNMENT_LEFT)
+    {
+        if (rq->alignment == RAQM_ALIGNMENT_RIGHT)
+        {
+            current_line = -1;
+            for (i = glyphs_length - 1; i >= 0; i--)
+            {
+                if (rq->glyphs[i].line != current_line)
+                {
+                    current_line = rq->glyphs[i].line;
+                    align_offset = rq->line_width - (rq->glyphs[i].x_position + rq->glyphs[i].x_advance);
+                    for (j = i; j >= 0 && rq->glyphs[j].line == current_line; j--)
+                    {
+                        rq->glyphs[j].x_position += align_offset;
+                    }
+                }
+                i = j + 1;
+            }
+        }
+
+        if (rq->alignment == RAQM_ALIGNMENT_CENTER)
+        {
+            current_line = -1;
+            for (i = glyphs_length - 1; i >= 0; i--)
+            {
+                if (rq->glyphs[i].line != current_line)
+                {
+                    current_line = rq->glyphs[i].line;
+                    align_offset = (rq->line_width - (rq->glyphs[i].x_position + rq->glyphs[i].x_advance)) / 2;
+                    for (j = i; j >= 0 && rq->glyphs[j].line == current_line; j--)
+                    {
+                        rq->glyphs[j].x_position += align_offset;
+                    }
+                }
+                i = j + 1;
+            }
+        }    
+    }
+
+    free (break_here);
+    return true;
 }
 
 static bool

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1152,6 +1152,41 @@ _raqm_line_break (raqm_t *rq)
                 i = j + 1;
             }
         }    
+        if (rq->alignment == RAQM_ALIGNMENT_FULL)
+        {
+            current_line = -1;
+            for (i = glyphs_length - 1; i >= 0; i--)
+            {
+                if (rq->glyphs[i].line != current_line)
+                {
+                    current_line = rq->glyphs[i].line;
+                    align_offset = rq->line_width - (rq->glyphs[i].x_position + rq->glyphs[i].x_advance);
+
+                    /* counting spaces in one line */
+                    for (j = i; j >= 0 && rq->glyphs[j].line == current_line; j--)
+                    {
+                        if (rq->text[rq->glyphs[j].cluster] == 32) //space
+                            space_count++;
+                    }
+
+                    /* distributing align offset to all spaces */
+                    if (space_count == 0)
+                        align_offset = 0;
+                    else
+                        align_offset = align_offset / space_count;
+                    space_extension = 0;
+                    for (k = j + 1; rq->glyphs[k].line == current_line; k++)
+                    {
+                        rq->glyphs[k].x_position += space_extension;
+                        if (rq->text[rq->glyphs[k].cluster] == 32) //space
+                        {
+                            space_extension += align_offset;
+                        }
+                    }
+                }
+                i = j + 1;
+            }
+        }
     }
 
     free (break_here);

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -72,7 +72,7 @@ typedef enum
  * @RAQM_ALIGNMENT_RIGHT: Paragraph is right aligned.
  * @RAQM_ALIGNMENT_LEFT: Paragraph is left aligned.
  * @RAQM_ALIGNMENT_CENTER: Paragraph is center aligned..
- *
+ * @RAQM_ALIGNMENT_FULL: Paragraph is full justified.
  *
  * Since: 0.2
  */
@@ -81,6 +81,7 @@ typedef enum
     RAQM_ALIGNMENT_RIGHT,
     RAQM_ALIGNMENT_LEFT,
     RAQM_ALIGNMENT_CENTER,
+    RAQM_ALIGNMENT_FULL,
 } raqm_alignment_t;
 
 /**

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -30,6 +30,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
@@ -67,6 +68,22 @@ typedef enum
 } raqm_direction_t;
 
 /**
+ * raqm_alignment_t:
+ * @RAQM_ALIGNMENT_RIGHT: Paragraph is right aligned.
+ * @RAQM_ALIGNMENT_LEFT: Paragraph is left aligned.
+ * @RAQM_ALIGNMENT_CENTER: Paragraph is center aligned..
+ *
+ *
+ * Since: 0.2
+ */
+typedef enum
+{
+    RAQM_ALIGNMENT_RIGHT,
+    RAQM_ALIGNMENT_LEFT,
+    RAQM_ALIGNMENT_CENTER,
+} raqm_alignment_t;
+
+/**
  * raqm_glyph_t:
  * @index: the index of the glyph in the font file.
  * @x_advance: the glyph advance width in horizontal text.
@@ -81,10 +98,14 @@ typedef enum
  */
 typedef struct raqm_glyph_t {
     unsigned int index;
+    int visual_index;
+    int line;
     int x_advance;
     int y_advance;
     int x_offset;
     int y_offset;
+    int x_position;
+    int y_position;
     uint32_t cluster;
     FT_Face ftface;
 } raqm_glyph_t;
@@ -126,6 +147,14 @@ raqm_set_freetype_face_range (raqm_t *rq,
                               FT_Face face,
                               size_t  start,
                               size_t  len);
+
+bool
+raqm_set_line_width (raqm_t *rq,
+                     int    width);
+
+bool
+raqm_set_paragraph_alignment (raqm_t           *rq,
+                              raqm_alignment_t align);
 
 bool
 raqm_layout (raqm_t *rq);

--- a/tests/features-arabic.test
+++ b/tests/features-arabic.test
@@ -45,19 +45,19 @@ Final Runs:
 run[0]:	 start: 0	length: 13	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [390]	x_offset: 0	y_offset: 0	x_advance: 756	font: Amiri
-glyph [423]	x_offset: 0	y_offset: 0	x_advance: 1566	font: Amiri
-glyph [389]	x_offset: 0	y_offset: 0	x_advance: 1897	font: Amiri
-glyph [398]	x_offset: 0	y_offset: 0	x_advance: 819	font: Amiri
-glyph [406]	x_offset: 0	y_offset: 0	x_advance: 1107	font: Amiri
-glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	font: Amiri
-glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [390]	x_offset: 0	y_offset: 0	x_advance: 756	font: Amiri
-glyph [407]	x_offset: 0	y_offset: 0	x_advance: 1107	font: Amiri
-glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	font: Amiri
-glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	font: Amiri
-glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	font: Amiri
+glyph [390]	x_offset: 0	y_offset: 0	x_advance: 756	x_position: 0	y_position: 0	font: Amiri
+glyph [423]	x_offset: 0	y_offset: 0	x_advance: 1566	x_position: 756	y_position: 0	font: Amiri
+glyph [389]	x_offset: 0	y_offset: 0	x_advance: 1897	x_position: 2322	y_position: 0	font: Amiri
+glyph [398]	x_offset: 0	y_offset: 0	x_advance: 819	x_position: 4219	y_position: 0	font: Amiri
+glyph [406]	x_offset: 0	y_offset: 0	x_advance: 1107	x_position: 5038	y_position: 0	font: Amiri
+glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	x_position: 6145	y_position: 0	font: Amiri
+glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	x_position: 7381	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 7827	y_position: 0	font: Amiri
+glyph [390]	x_offset: 0	y_offset: 0	x_advance: 756	x_position: 8427	y_position: 0	font: Amiri
+glyph [407]	x_offset: 0	y_offset: 0	x_advance: 1107	x_position: 9183	y_position: 0	font: Amiri
+glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	x_position: 10290	y_position: 0	font: Amiri
+glyph [417]	x_offset: 0	y_offset: 0	x_advance: 1236	x_position: 11526	y_position: 0	font: Amiri
+glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	x_position: 12762	y_position: 0	font: Amiri
 
 UTF-32 clusters: 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  23 21 19 17 15 13 11 10 08 06 04 02 00

--- a/tests/features-kerning.test
+++ b/tests/features-kerning.test
@@ -45,19 +45,19 @@ Final Runs:
 run[0]:	 start: 0	length: 13	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [47]	x_offset: 0	y_offset: 0	x_advance: 1128	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [88]	x_offset: 0	y_offset: 0	x_advance: 1030	font: Amiri
-glyph [91]	x_offset: 0	y_offset: 0	x_advance: 952	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [54]	x_offset: 0	y_offset: 0	x_advance: 1004	font: Amiri
-glyph [88]	x_offset: 0	y_offset: 0	x_advance: 1030	font: Amiri
-glyph [83]	x_offset: 0	y_offset: 0	x_advance: 1020	font: Amiri
-glyph [83]	x_offset: 0	y_offset: 0	x_advance: 1020	font: Amiri
-glyph [82]	x_offset: 0	y_offset: 0	x_advance: 1018	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [87]	x_offset: 0	y_offset: 0	x_advance: 622	font: Amiri
+glyph [47]	x_offset: 0	y_offset: 0	x_advance: 1128	x_position: 0	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 1128	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 1668	y_position: 0	font: Amiri
+glyph [88]	x_offset: 0	y_offset: 0	x_advance: 1030	x_position: 2732	y_position: 0	font: Amiri
+glyph [91]	x_offset: 0	y_offset: 0	x_advance: 952	x_position: 3762	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4714	y_position: 0	font: Amiri
+glyph [54]	x_offset: 0	y_offset: 0	x_advance: 1004	x_position: 5314	y_position: 0	font: Amiri
+glyph [88]	x_offset: 0	y_offset: 0	x_advance: 1030	x_position: 6318	y_position: 0	font: Amiri
+glyph [83]	x_offset: 0	y_offset: 0	x_advance: 1020	x_position: 7348	y_position: 0	font: Amiri
+glyph [83]	x_offset: 0	y_offset: 0	x_advance: 1020	x_position: 8368	y_position: 0	font: Amiri
+glyph [82]	x_offset: 0	y_offset: 0	x_advance: 1018	x_position: 9388	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 10406	y_position: 0	font: Amiri
+glyph [87]	x_offset: 0	y_offset: 0	x_advance: 622	x_position: 11172	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09 10 11 12
 UTF-8 clusters:  00 01 02 03 04 05 06 07 08 09 10 11 12

--- a/tests/features-ligature.test
+++ b/tests/features-ligature.test
@@ -49,21 +49,21 @@ Final Runs:
 run[0]:	 start: 0	length: 15	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [73]	x_offset: 0	y_offset: 0	x_advance: 616	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [73]	x_offset: 0	y_offset: 0	x_advance: 616	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
+glyph [73]	x_offset: 0	y_offset: 0	x_advance: 616	x_position: 0	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 616	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 1156	y_position: 0	font: Amiri
+glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	x_position: 1666	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 2526	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3126	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 3666	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4404	y_position: 0	font: Amiri
+glyph [73]	x_offset: 0	y_offset: 0	x_advance: 616	x_position: 5004	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 5620	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 6160	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 6670	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 7180	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 7720	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 8784	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14
 UTF-8 clusters:  00 01 02 03 04 05 06 07 08 09 10 11 12 13 14

--- a/tests/multi-fonts.test
+++ b/tests/multi-fonts.test
@@ -64,27 +64,27 @@ run[1]:	 start: 10	length: 11	direction: rtl	script: Arab	font: Aref Ruqaa
 run[2]:	 start: 8	length: 2	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	font: Aref Ruqaa
-glyph [2320]	x_offset: 0	y_offset: 0	x_advance: 360	font: Amiri
-glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	font: Amiri
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	x_position: 0	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 1174	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 2238	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 3170	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3680	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 4220	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 4958	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 5990	y_position: 0	font: Amiri
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 6590	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 7338	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 8086	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 8834	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 9582	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 10330	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 11078	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 11826	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 12574	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 13322	y_position: 0	font: Aref Ruqaa
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 748	x_position: 14070	y_position: 0	font: Aref Ruqaa
+glyph [2320]	x_offset: 0	y_offset: 0	x_advance: 360	x_position: 14818	y_position: 0	font: Amiri
+glyph [388]	x_offset: 0	y_offset: 0	x_advance: 446	x_position: 15178	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 20 19 18 17 16 15 14 13 12 11 10 09 08
 UTF-8 clusters:  00 01 02 03 04 05 06 07 31 29 27 25 23 21 19 18 16 14 12 10 08

--- a/tests/multi-fonts2.test
+++ b/tests/multi-fonts2.test
@@ -29,10 +29,10 @@ run[1]:	 start: 1	length: 2	direction: rtl	script: Arab	font: DejaVu Sans
 run[2]:	 start: 0	length: 1	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [2454]	x_offset: 0	y_offset: 0	x_advance: 1200	font: Amiri
-glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [2454]	x_offset: 0	y_offset: 0	x_advance: 1200	x_position: 0	y_position: 0	font: Amiri
+glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	x_position: 1200	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 1770	y_position: 0	font: DejaVu Sans
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 2900	y_position: 0	font: Amiri
 
 UTF-32 clusters: 03 02 01 00
 UTF-8 clusters:  06 04 02 00

--- a/tests/scripts-backward-ltr.test
+++ b/tests/scripts-backward-ltr.test
@@ -99,41 +99,41 @@ run[7]:	 start: 28	length: 2	direction: ltr	script: Arab	font: DejaVu Sans
 run[8]:	 start: 30	length: 5	direction: rtl	script: Arab	font: DejaVu Sans
 
 Glyph information:
-glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	font: DejaVu Sans
-glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	font: DejaVu Sans
-glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	font: DejaVu Sans
-glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	font: DejaVu Sans
-glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	font: DejaVu Sans
-glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	font: DejaVu Sans
-glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	font: DejaVu Sans
-glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	font: DejaVu Sans
-glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	font: DejaVu Sans
-glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	font: DejaVu Sans
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
+glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 1363	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 2460	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 3806	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 4264	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 5420	y_position: 0	font: DejaVu Sans
+glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	x_position: 6604	y_position: 0	font: DejaVu Sans
+glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	x_position: 8155	y_position: 0	font: DejaVu Sans
+glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 9235	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 9804	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 11150	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 11608	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 12764	y_position: 0	font: DejaVu Sans
+glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	x_position: 13948	y_position: 0	font: DejaVu Sans
+glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	x_position: 15230	y_position: 0	font: DejaVu Sans
+glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	x_position: 16937	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 17507	y_position: 0	font: DejaVu Sans
+glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	x_position: 18637	y_position: 0	font: DejaVu Sans
+glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	x_position: 19859	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 19859	y_position: 0	font: DejaVu Sans
+glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	x_position: 20658	y_position: 0	font: DejaVu Sans
+glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 21918	y_position: 0	font: DejaVu Sans
+glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	x_position: 23216	y_position: 0	font: DejaVu Sans
+glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 24516	y_position: 0	font: DejaVu Sans
+glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 25085	y_position: 0	font: DejaVu Sans
+glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	x_position: 25654	y_position: 0	font: DejaVu Sans
+glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 26721	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 28019	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 28670	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 29469	y_position: 0	font: DejaVu Sans
+glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	x_position: 30120	y_position: 0	font: DejaVu Sans
+glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	x_position: 30744	y_position: 0	font: DejaVu Sans
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	x_position: 31362	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 32628	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 33758	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00 18 18 20 21 22 23 24 25 26 27 28 29 34 33 32 31 30
 UTF-8 clusters:  34 32 30 28 26 24 22 20 18 16 14 12 10 08 06 04 02 00 36 36 39 40 41 42 43 44 45 46 47 48 57 55 53 51 49

--- a/tests/scripts-backward-rtl.test
+++ b/tests/scripts-backward-rtl.test
@@ -98,41 +98,41 @@ run[6]:	 start: 4	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
 run[7]:	 start: 0	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
 
 Glyph information:
-glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	font: DejaVu Sans
-glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	font: DejaVu Sans
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	font: DejaVu Sans
-glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	font: DejaVu Sans
-glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	font: DejaVu Sans
-glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	font: DejaVu Sans
-glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	font: DejaVu Sans
-glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	font: DejaVu Sans
-glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	font: DejaVu Sans
-glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	font: DejaVu Sans
+glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	x_position: 624	y_position: 0	font: DejaVu Sans
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	x_position: 1242	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 2508	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 3638	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 4735	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 5386	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 6185	y_position: 0	font: DejaVu Sans
+glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	x_position: 6836	y_position: 0	font: DejaVu Sans
+glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 8096	y_position: 0	font: DejaVu Sans
+glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	x_position: 9394	y_position: 0	font: DejaVu Sans
+glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 10694	y_position: 0	font: DejaVu Sans
+glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 11263	y_position: 0	font: DejaVu Sans
+glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	x_position: 11832	y_position: 0	font: DejaVu Sans
+glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 12899	y_position: 0	font: DejaVu Sans
+glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	x_position: 14197	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 14197	y_position: 0	font: DejaVu Sans
+glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	x_position: 14996	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 16359	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 17456	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 18802	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 19260	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 20416	y_position: 0	font: DejaVu Sans
+glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	x_position: 21600	y_position: 0	font: DejaVu Sans
+glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	x_position: 23151	y_position: 0	font: DejaVu Sans
+glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 24231	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 24800	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 26146	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 26604	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 27760	y_position: 0	font: DejaVu Sans
+glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	x_position: 28944	y_position: 0	font: DejaVu Sans
+glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	x_position: 30226	y_position: 0	font: DejaVu Sans
+glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	x_position: 31933	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 32503	y_position: 0	font: DejaVu Sans
+glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	x_position: 33633	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 34 33 32 31 30 29 28 27 20 21 22 23 24 25 26 18 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  57 55 53 51 49 48 47 46 39 40 41 42 43 44 45 36 36 34 32 30 28 26 24 22 20 18 16 14 12 10 08 06 04 02 00

--- a/tests/scripts-backward.test
+++ b/tests/scripts-backward.test
@@ -98,41 +98,41 @@ run[6]:	 start: 4	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
 run[7]:	 start: 0	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
 
 Glyph information:
-glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	font: DejaVu Sans
-glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	font: DejaVu Sans
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	font: DejaVu Sans
-glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	font: DejaVu Sans
-glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	font: DejaVu Sans
-glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	font: DejaVu Sans
-glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	font: DejaVu Sans
-glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
-glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	font: DejaVu Sans
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	font: DejaVu Sans
-glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	font: DejaVu Sans
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	font: DejaVu Sans
-glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	font: DejaVu Sans
-glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	font: DejaVu Sans
-glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	font: DejaVu Sans
+glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	x_position: 624	y_position: 0	font: DejaVu Sans
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	x_position: 1242	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 2508	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 3638	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 4735	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 5386	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 6185	y_position: 0	font: DejaVu Sans
+glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	x_position: 6836	y_position: 0	font: DejaVu Sans
+glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 8096	y_position: 0	font: DejaVu Sans
+glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	x_position: 9394	y_position: 0	font: DejaVu Sans
+glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 10694	y_position: 0	font: DejaVu Sans
+glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 11263	y_position: 0	font: DejaVu Sans
+glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	x_position: 11832	y_position: 0	font: DejaVu Sans
+glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	x_position: 12899	y_position: 0	font: DejaVu Sans
+glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	x_position: 14197	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 14197	y_position: 0	font: DejaVu Sans
+glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	x_position: 14996	y_position: 0	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	x_position: 16359	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 17456	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 18802	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 19260	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 20416	y_position: 0	font: DejaVu Sans
+glyph [46]	x_offset: 0	y_offset: 0	x_advance: 1551	x_position: 21600	y_position: 0	font: DejaVu Sans
+glyph [53]	x_offset: 0	y_offset: 0	x_advance: 1080	x_position: 23151	y_position: 0	font: DejaVu Sans
+glyph [16]	x_offset: 0	y_offset: 0	x_advance: 569	x_position: 24231	y_position: 0	font: DejaVu Sans
+glyph [15]	x_offset: 0	y_offset: 0	x_advance: 1346	x_position: 24800	y_position: 0	font: DejaVu Sans
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 458	x_position: 26146	y_position: 0	font: DejaVu Sans
+glyph [14]	x_offset: 0	y_offset: 0	x_advance: 1156	x_position: 26604	y_position: 0	font: DejaVu Sans
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 1184	x_position: 27760	y_position: 0	font: DejaVu Sans
+glyph [13]	x_offset: 0	y_offset: 0	x_advance: 1282	x_position: 28944	y_position: 0	font: DejaVu Sans
+glyph [56]	x_offset: 0	y_offset: 0	x_advance: 1707	x_position: 30226	y_position: 0	font: DejaVu Sans
+glyph [37]	x_offset: 0	y_offset: 0	x_advance: 570	x_position: 31933	y_position: 0	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	x_position: 32503	y_position: 0	font: DejaVu Sans
+glyph [44]	x_offset: 0	y_offset: 0	x_advance: 1222	x_position: 33633	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 34 33 32 31 30 29 28 27 20 21 22 23 24 25 26 18 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  57 55 53 51 49 48 47 46 39 40 41 42 43 44 45 36 36 34 32 30 28 26 24 22 20 18 16 14 12 10 08 06 04 02 00

--- a/tests/scripts-forward-ltr.test
+++ b/tests/scripts-forward-ltr.test
@@ -55,22 +55,22 @@ run[3]:	 start: 11	length: 1	direction: ltr	script: Grek	font: DejaVu Sans
 run[4]:	 start: 12	length: 4	direction: ltr	script: Cyrl	font: DejaVu Sans
 
 Glyph information:
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 1229	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 2458	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 3687	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 4916	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 5567	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 6366	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 7595	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 8824	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 10053	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 10852	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 11503	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 12732	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 13961	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 15190	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 16419	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15
 UTF-8 clusters:  00 01 02 03 04 05 06 08 10 12 13 14 16 18 20 22

--- a/tests/scripts-forward-rtl.test
+++ b/tests/scripts-forward-rtl.test
@@ -55,22 +55,22 @@ run[3]:	 start: 11	length: 1	direction: ltr	script: Grek	font: DejaVu Sans
 run[4]:	 start: 12	length: 4	direction: ltr	script: Cyrl	font: DejaVu Sans
 
 Glyph information:
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 1229	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 2458	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 3687	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 4916	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 5567	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 6366	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 7595	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 8824	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 10053	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 10852	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 11503	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 12732	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 13961	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 15190	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 16419	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15
 UTF-8 clusters:  00 01 02 03 04 05 06 08 10 12 13 14 16 18 20 22

--- a/tests/scripts-forward.test
+++ b/tests/scripts-forward.test
@@ -55,22 +55,22 @@ run[3]:	 start: 11	length: 1	direction: ltr	script: Grek	font: DejaVu Sans
 run[4]:	 start: 12	length: 4	direction: ltr	script: Cyrl	font: DejaVu Sans
 
 Glyph information:
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 0	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 1229	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 2458	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 3687	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 4916	y_position: 0	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 5567	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 6366	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 7595	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 8824	y_position: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	x_position: 10053	y_position: 0	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	x_position: 10852	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 11503	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 12732	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 13961	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 15190	y_position: 0	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	x_position: 16419	y_position: 0	font: DejaVu Sans
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15
 UTF-8 clusters:  00 01 02 03 04 05 06 08 10 12 13 14 16 18 20 22

--- a/tests/test1.test
+++ b/tests/test1.test
@@ -62,25 +62,25 @@ run[2]:	 start: 5	length: 7	direction: ltr	script: Latn	font: Amiri
 run[3]:	 start: 0	length: 5	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 0	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 975	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 1684	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 2654	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3632	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 4232	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 5172	y_position: 0	font: Amiri
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	x_position: 5772	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 6946	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 8010	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 8942	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 9452	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 9992	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 10730	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 11762	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 12702	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 13677	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 14386	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 15356	y_position: 0	font: Amiri
 
 UTF-32 clusters: 18 17 16 15 14 13 12 05 06 07 08 09 10 11 04 03 02 01 00
 UTF-8 clusters:  25 23 21 19 18 17 16 09 10 11 12 13 14 15 08 06 04 02 00

--- a/tests/test1_LTR.test
+++ b/tests/test1_LTR.test
@@ -63,25 +63,25 @@ run[3]:	 start: 13	length: 2	direction: ltr	script: Arab	font: Amiri
 run[4]:	 start: 15	length: 4	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 0	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 975	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 1684	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 2654	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 3632	y_position: 0	font: Amiri
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	x_position: 4572	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 5746	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 6810	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 7742	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 8252	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 8792	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 9530	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 10562	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 11162	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 12102	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 12702	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 13677	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 14386	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 15356	y_position: 0	font: Amiri
 
 UTF-32 clusters: 03 02 01 00 04 05 06 07 08 09 10 11 12 13 14 18 17 16 15
 UTF-8 clusters:  06 04 02 00 08 09 10 11 12 13 14 15 16 17 18 25 23 21 19

--- a/tests/test1_RTL.test
+++ b/tests/test1_RTL.test
@@ -62,25 +62,25 @@ run[2]:	 start: 5	length: 7	direction: ltr	script: Latn	font: Amiri
 run[3]:	 start: 0	length: 5	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 0	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 975	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 1684	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 2654	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3632	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 4232	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 5172	y_position: 0	font: Amiri
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1174	x_position: 5772	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 6946	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 8010	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 8942	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 9452	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 9992	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 10730	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 11762	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 12702	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 13677	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 14386	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 15356	y_position: 0	font: Amiri
 
 UTF-32 clusters: 18 17 16 15 14 13 12 05 06 07 08 09 10 11 04 03 02 01 00
 UTF-8 clusters:  25 23 21 19 18 17 16 09 10 11 12 13 14 15 08 06 04 02 00

--- a/tests/test2.test
+++ b/tests/test2.test
@@ -53,21 +53,21 @@ run[1]:	 start: 12	length: 3	direction: ltr	script: Arab	font: Amiri
 run[2]:	 start: 7	length: 5	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 862	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 1628	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 2490	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3486	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 4026	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4872	y_position: 0	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 5472	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 6562	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 7652	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 8742	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 9342	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 10317	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 11026	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 11996	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 12 13 14 11 10 09 08 07
 UTF-8 clusters:  00 01 02 03 04 05 06 16 17 18 15 13 11 09 07

--- a/tests/test2_LTR.test
+++ b/tests/test2_LTR.test
@@ -53,21 +53,21 @@ run[1]:	 start: 12	length: 3	direction: ltr	script: Arab	font: Amiri
 run[2]:	 start: 7	length: 5	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 862	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 1628	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 2490	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3486	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 4026	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4872	y_position: 0	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 5472	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 6562	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 7652	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 8742	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 9342	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 10317	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 11026	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 11996	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 12 13 14 11 10 09 08 07
 UTF-8 clusters:  00 01 02 03 04 05 06 16 17 18 15 13 11 09 07

--- a/tests/test2_RTL.test
+++ b/tests/test2_RTL.test
@@ -54,21 +54,21 @@ run[2]:	 start: 6	length: 1	direction: rtl	script: Latn	font: Amiri
 run[3]:	 start: 0	length: 6	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 0	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 1090	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 2180	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3270	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 3870	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 4845	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 5554	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 6524	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 7502	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 8102	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 8964	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 9730	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 10592	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 11588	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 12128	y_position: 0	font: Amiri
 
 UTF-32 clusters: 12 13 14 11 10 09 08 07 06 00 01 02 03 04 05
 UTF-8 clusters:  16 17 18 15 13 11 09 07 06 00 01 02 03 04 05

--- a/tests/test3.test
+++ b/tests/test3.test
@@ -84,34 +84,34 @@ run[4]:	 start: 20	length: 1	direction: ltr	script: Arab	font: Amiri
 run[5]:	 start: 21	length: 7	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 862	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 1628	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 2490	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3486	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 4026	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4872	y_position: 0	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 5472	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 6645	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 7115	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 7559	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 8564	y_position: 0	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 9164	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 10254	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 11344	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 12434	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 13034	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 14009	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 14718	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 15688	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 16666	y_position: 0	font: Amiri
+glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	x_position: 17266	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 18126	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 19190	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 20122	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 20632	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 21172	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 21910	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 19 18 17 16 15 12 13 14 11 10 09 08 07 20 21 22 23 24 25 26 27
 UTF-8 clusters:  00 01 02 03 04 05 06 26 24 22 20 19 16 17 18 15 13 11 09 07 28 29 30 31 32 33 34 35

--- a/tests/test3_LTR.test
+++ b/tests/test3_LTR.test
@@ -84,34 +84,34 @@ run[4]:	 start: 20	length: 1	direction: ltr	script: Arab	font: Amiri
 run[5]:	 start: 21	length: 7	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 862	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 1628	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 2490	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3486	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 4026	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 4872	y_position: 0	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 5472	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 6645	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 7115	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 7559	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 8564	y_position: 0	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 9164	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 10254	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 11344	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 12434	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 13034	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 14009	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 14718	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 15688	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 16666	y_position: 0	font: Amiri
+glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	x_position: 17266	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 18126	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 19190	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 20122	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 20632	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 21172	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 21910	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 19 18 17 16 15 12 13 14 11 10 09 08 07 20 21 22 23 24 25 26 27
 UTF-8 clusters:  00 01 02 03 04 05 06 26 24 22 20 19 16 17 18 15 13 11 09 07 28 29 30 31 32 33 34 35

--- a/tests/test3_RTL.test
+++ b/tests/test3_RTL.test
@@ -84,34 +84,34 @@ run[4]:	 start: 6	length: 1	direction: rtl	script: Latn	font: Amiri
 run[5]:	 start: 0	length: 6	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	font: Amiri
-glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	font: Amiri
-glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	font: Amiri
-glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	font: Amiri
-glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	font: Amiri
-glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	font: Amiri
-glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	font: Amiri
-glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	font: Amiri
-glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	font: Amiri
+glyph [72]	x_offset: 0	y_offset: 0	x_advance: 860	x_position: 0	y_position: 0	font: Amiri
+glyph [81]	x_offset: 0	y_offset: 0	x_advance: 1064	x_position: 860	y_position: 0	font: Amiri
+glyph [74]	x_offset: 0	y_offset: 0	x_advance: 932	x_position: 1924	y_position: 0	font: Amiri
+glyph [79]	x_offset: 0	y_offset: 0	x_advance: 510	x_position: 2856	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 3366	y_position: 0	font: Amiri
+glyph [86]	x_offset: 0	y_offset: 0	x_advance: 738	x_position: 3906	y_position: 0	font: Amiri
+glyph [75]	x_offset: 0	y_offset: 0	x_advance: 1032	x_position: 4644	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 5676	y_position: 0	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 6276	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 7449	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 7919	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 8363	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 9368	y_position: 0	font: Amiri
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 9968	y_position: 0	font: Amiri
+glyph [21]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 11058	y_position: 0	font: Amiri
+glyph [22]	x_offset: 0	y_offset: 0	x_advance: 1090	x_position: 12148	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 13238	y_position: 0	font: Amiri
+glyph [5132]	x_offset: 0	y_offset: 0	x_advance: 975	x_position: 13838	y_position: 0	font: Amiri
+glyph [5049]	x_offset: 0	y_offset: 0	x_advance: 529	x_position: 14813	y_position: 0	font: Amiri
+glyph [3104]	x_offset: 180	y_offset: 0	x_advance: 1150	x_position: 15522	y_position: 0	font: Amiri
+glyph [2040]	x_offset: 0	y_offset: 0	x_advance: 978	x_position: 16492	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 17470	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 18070	y_position: 0	font: Amiri
+glyph [85]	x_offset: 0	y_offset: 0	x_advance: 766	x_position: 18932	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 19698	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 20560	y_position: 0	font: Amiri
+glyph [76]	x_offset: 0	y_offset: 0	x_advance: 540	x_position: 21556	y_position: 0	font: Amiri
+glyph [70]	x_offset: 0	y_offset: 0	x_advance: 846	x_position: 22096	y_position: 0	font: Amiri
 
 UTF-32 clusters: 21 22 23 24 25 26 27 20 19 18 17 16 15 12 13 14 11 10 09 08 07 06 00 01 02 03 04 05
 UTF-8 clusters:  29 30 31 32 33 34 35 28 26 24 22 20 19 16 17 18 15 13 11 09 07 06 00 01 02 03 04 05

--- a/tests/test4.test
+++ b/tests/test4.test
@@ -55,24 +55,24 @@ Final Runs:
 run[0]:	 start: 0	length: 18	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	font: Amiri
-glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	font: Amiri
-glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	font: Amiri
-glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	font: Amiri
-glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	font: Amiri
-glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	font: Amiri
-glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 0	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 1173	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 1643	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 2087	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3092	y_position: 0	font: Amiri
+glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	x_position: 3692	y_position: 0	font: Amiri
+glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	x_position: 4653	y_position: 0	font: Amiri
+glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	x_position: 5054	y_position: 0	font: Amiri
+glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	x_position: 6534	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 7331	y_position: 0	font: Amiri
+glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	x_position: 7931	y_position: 0	font: Amiri
+glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	x_position: 8347	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 8835	y_position: 0	font: Amiri
+glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	x_position: 9305	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 10469	y_position: 0	font: Amiri
+glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	x_position: 11069	y_position: 0	font: Amiri
+glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	x_position: 12879	y_position: 0	font: Amiri
+glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	x_position: 13379	y_position: 0	font: Amiri
 
 UTF-32 clusters: 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  31 29 27 25 24 22 20 18 16 15 13 11 09 07 06 04 02 00

--- a/tests/test4_LTR.test
+++ b/tests/test4_LTR.test
@@ -55,24 +55,24 @@ Final Runs:
 run[0]:	 start: 0	length: 18	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	font: Amiri
-glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	font: Amiri
-glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	font: Amiri
-glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	font: Amiri
-glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	font: Amiri
-glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	font: Amiri
-glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 0	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 1173	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 1643	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 2087	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3092	y_position: 0	font: Amiri
+glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	x_position: 3692	y_position: 0	font: Amiri
+glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	x_position: 4653	y_position: 0	font: Amiri
+glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	x_position: 5054	y_position: 0	font: Amiri
+glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	x_position: 6534	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 7331	y_position: 0	font: Amiri
+glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	x_position: 7931	y_position: 0	font: Amiri
+glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	x_position: 8347	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 8835	y_position: 0	font: Amiri
+glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	x_position: 9305	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 10469	y_position: 0	font: Amiri
+glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	x_position: 11069	y_position: 0	font: Amiri
+glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	x_position: 12879	y_position: 0	font: Amiri
+glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	x_position: 13379	y_position: 0	font: Amiri
 
 UTF-32 clusters: 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  31 29 27 25 24 22 20 18 16 15 13 11 09 07 06 04 02 00

--- a/tests/test4_RTL.test
+++ b/tests/test4_RTL.test
@@ -55,24 +55,24 @@ Final Runs:
 run[0]:	 start: 0	length: 18	direction: rtl	script: Arab	font: Amiri
 
 Glyph information:
-glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	font: Amiri
-glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	font: Amiri
-glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	font: Amiri
-glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	font: Amiri
-glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	font: Amiri
-glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	font: Amiri
-glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	font: Amiri
-glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	font: Amiri
-glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	font: Amiri
-glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	font: Amiri
+glyph [419]	x_offset: 0	y_offset: 0	x_advance: 1173	x_position: 0	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 1173	y_position: 0	font: Amiri
+glyph [4992]	x_offset: 0	y_offset: 0	x_advance: 444	x_position: 1643	y_position: 0	font: Amiri
+glyph [4959]	x_offset: 0	y_offset: 0	x_advance: 1005	x_position: 2087	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 3092	y_position: 0	font: Amiri
+glyph [2926]	x_offset: 0	y_offset: 0	x_advance: 961	x_position: 3692	y_position: 0	font: Amiri
+glyph [2914]	x_offset: 0	y_offset: 0	x_advance: 401	x_position: 4653	y_position: 0	font: Amiri
+glyph [2382]	x_offset: 0	y_offset: 0	x_advance: 1480	x_position: 5054	y_position: 0	font: Amiri
+glyph [2334]	x_offset: 0	y_offset: 0	x_advance: 797	x_position: 6534	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 7331	y_position: 0	font: Amiri
+glyph [5199]	x_offset: 0	y_offset: 0	x_advance: 416	x_position: 7931	y_position: 0	font: Amiri
+glyph [5154]	x_offset: 0	y_offset: 0	x_advance: 488	x_position: 8347	y_position: 0	font: Amiri
+glyph [2018]	x_offset: 0	y_offset: 0	x_advance: 470	x_position: 8835	y_position: 0	font: Amiri
+glyph [2396]	x_offset: 0	y_offset: 0	x_advance: 1164	x_position: 9305	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 10469	y_position: 0	font: Amiri
+glyph [2052]	x_offset: 0	y_offset: 0	x_advance: 1810	x_position: 11069	y_position: 0	font: Amiri
+glyph [4494]	x_offset: 0	y_offset: 0	x_advance: 500	x_position: 12879	y_position: 0	font: Amiri
+glyph [4460]	x_offset: 0	y_offset: 0	x_advance: 478	x_position: 13379	y_position: 0	font: Amiri
 
 UTF-32 clusters: 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
 UTF-8 clusters:  31 29 27 25 24 22 20 18 16 15 13 11 09 07 06 04 02 00

--- a/tests/test5.test
+++ b/tests/test5.test
@@ -39,16 +39,16 @@ Final Runs:
 run[0]:	 start: 0	length: 10	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 862	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 1724	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 2324	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 3264	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	x_position: 4260	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 5196	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 6136	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 6736	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 7598	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09
 UTF-8 clusters:  00 01 02 03 04 05 06 07 08 09

--- a/tests/test5_LTR.test
+++ b/tests/test5_LTR.test
@@ -39,16 +39,16 @@ Final Runs:
 run[0]:	 start: 0	length: 10	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 862	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 1724	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 2324	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 3264	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	x_position: 4260	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 5196	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 6136	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 6736	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 7598	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09
 UTF-8 clusters:  00 01 02 03 04 05 06 07 08 09

--- a/tests/test5_RTL.test
+++ b/tests/test5_RTL.test
@@ -39,16 +39,16 @@ Final Runs:
 run[0]:	 start: 0	length: 10	direction: ltr	script: Latn	font: Amiri
 
 Glyph information:
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	font: Amiri
-glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	font: Amiri
-glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	font: Amiri
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
-glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 0	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 862	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 1724	y_position: 0	font: Amiri
+glyph [11]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 2324	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 996	x_position: 3264	y_position: 0	font: Amiri
+glyph [69]	x_offset: 0	y_offset: 0	x_advance: 936	x_position: 4260	y_position: 0	font: Amiri
+glyph [12]	x_offset: 0	y_offset: 0	x_advance: 940	x_position: 5196	y_position: 0	font: Amiri
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 600	x_position: 6136	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 6736	y_position: 0	font: Amiri
+glyph [68]	x_offset: 0	y_offset: 0	x_advance: 862	x_position: 7598	y_position: 0	font: Amiri
 
 UTF-32 clusters: 00 01 02 03 04 05 06 07 08 09
 UTF-8 clusters:  00 01 02 03 04 05 06 07 08 09

--- a/tests/xyoffset.test
+++ b/tests/xyoffset.test
@@ -25,11 +25,11 @@ Final Runs:
 run[0]:	 start: 0	length: 3	direction: rtl	script: Arab	font: Aref Ruqaa
 
 Glyph information:
-glyph [4]	x_offset: 783	y_offset: 50	x_advance: 0	font: Aref Ruqaa
-glyph [6]	x_offset: 0	y_offset: 0	x_advance: 302	font: Aref Ruqaa
-glyph [4]	x_offset: 909	y_offset: 1075	x_advance: 0	font: Aref Ruqaa
-glyph [10]	x_offset: 0	y_offset: 868	x_advance: 432	font: Aref Ruqaa
-glyph [9]	x_offset: 0	y_offset: 1664	x_advance: 1054	font: Aref Ruqaa
+glyph [4]	x_offset: 783	y_offset: 50	x_advance: 0	x_position: 783	y_position: 50	font: Aref Ruqaa
+glyph [6]	x_offset: 0	y_offset: 0	x_advance: 302	x_position: 0	y_position: 0	font: Aref Ruqaa
+glyph [4]	x_offset: 909	y_offset: 1075	x_advance: 0	x_position: 1211	y_position: 1075	font: Aref Ruqaa
+glyph [10]	x_offset: 0	y_offset: 868	x_advance: 432	x_position: 302	y_position: 868	font: Aref Ruqaa
+glyph [9]	x_offset: 0	y_offset: 1664	x_advance: 1054	x_position: 734	y_position: 1664	font: Aref Ruqaa
 
 UTF-32 clusters: 02 02 01 01 00
 UTF-8 clusters:  04 04 02 02 00


### PR DESCRIPTION
-The first commit adds the line breaking support + paragraph alignment feature (right, left and center) only.
    **_To do:_**
- Add test files for the alignment.
- Fix error: in the right alignment the text get shifted more than it's supposed to. 

-Next commit, is just my _failed_ attempt to perform full justification for the text. It works well sometimes (rarely), other times it gets applied on the last line only, I couldn’t figure out the problem.
