### PR TITLE
Allocate unicode on heap, not stack.

### DIFF
--- a/src/raqm.c
+++ b/src/raqm.c
@@ -434,12 +434,9 @@ raqm_set_text_utf8 (raqm_t         *rq,
                     const char     *text,
                     size_t          len)
 {
-#ifdef _MSC_VER
-  uint32_t *unicode = _alloca (sizeof (uint32_t) * len);
-#else
-  uint32_t unicode[len];
-#endif
+  uint32_t *unicode;
   size_t ulen;
+  bool result = false;
 
   if (!rq || !text || !len)
     return false;
@@ -452,12 +449,19 @@ raqm_set_text_utf8 (raqm_t         *rq,
   if (!rq->text_utf8)
     return false;
 
+  unicode = calloc (len, sizeof(uint32_t));
+  if (!unicode)
+    goto fail;
+
   memcpy (rq->text_utf8, text, sizeof (char) * strlen (text));
 
   ulen = fribidi_charset_to_unicode (FRIBIDI_CHAR_SET_UTF8,
                                      text, len, unicode);
 
-  return raqm_set_text (rq, unicode, ulen);
+  result = raqm_set_text (rq, unicode, ulen);
+ fail:
+  free(unicode);
+  return result;
 }
 
 /**


### PR DESCRIPTION
Note -- This is incomplete and requires more work. 

While testing a memory leak in Pillow, I threw a large string into the font rendering (~10 megs) which segfaulted the interpreter in raqm_set_text_utf8. Allocating the unicode array with malloc instead of on the stack fixed that issue. (note, I'm on linux/mac. _alloca on windows may perform differently, but it's been deprecated according to this: https://msdn.microsoft.com/en-us/library/wb1s57t5.aspx)

This is a small patch to do the allocation with malloc, and free afterwards. 

This is incomplete, in that there's a segfault further in the render that I haven't traced down yet here: https://github.com/HOST-Oman/libraqm/blob/v0.2.0/src/raqm.c#L1022.






