### PR TITLE
Fix raqm build when compiling against old HarfBuzz versions

### DIFF
--- a/src/raqm.c
+++ b/src/raqm.c
@@ -805,7 +805,8 @@ raqm_set_invisible_glyph (raqm_t *rq,
     return false;
 #endif
 
-#if !HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
+#if !defined(HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES) || \
+    !HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
   if (gid < 0)
     return false;
 #endif
@@ -1557,7 +1558,8 @@ _raqm_shape (raqm_t *rq)
 {
   hb_buffer_flags_t hb_buffer_flags = HB_BUFFER_FLAG_BOT | HB_BUFFER_FLAG_EOT;
 
-#if HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
+#if defined(HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES) && \
+    HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
   if (rq->invisible_glyph < 0)
     hb_buffer_flags |= HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES;
 #endif

--- a/tests/raqm-test.c
+++ b/tests/raqm-test.c
@@ -92,7 +92,8 @@ has_requirement (char *req)
 #endif
 
   if (strcmp (req, "HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES") == 0)
-#ifdef HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
+#if defined(HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES) && \
+        HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES
     return true;
 #else
     return false;


### PR DESCRIPTION
Autoconf (at least in version 2.69) has an interesting quirk:
When `AC_CHECK_FUNCS` detects that a function foo is unavailable,
it emits `#undef HAVE_FOO` into the generated `config.h`, whereas
`AC_CHECK_DECLS` emits `#define HAVE_DECL_FOO 0`. We now test
for defined-ness and the acutal value of HAVE_DECL_FOO, so we're
resilient in case autoconf ever makes `AC_CHECK_DECLS` behave like
`AC_CHECK_FUNCS`.