### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,16 @@ matrix:
     - os: osx
       install:
         - export XML_CATALOG_FILES="/usr/local/etc/xml/catalog" # for the docs
+    #powerjobs
+    - os: linux
+      arch: ppc64le
+      after_success:
+        - bash .ci/deploy-docs.sh
 
+    - os: linux
+      arch: ppc64le
+      compiler: clang
+   
 before_script:
   - ./autogen.sh
   - ./configure --enable-gtk-doc


### PR DESCRIPTION
Add support for architecture ppc64le.

It has failed on osx, passed on ppc64le.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
