### PR TITLE
Meson: Support building with Visual Studio

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,10 +8,40 @@ project('raqm', 'c',
 
 raqm_version = meson.project_version().split('.')
 
-freetype = dependency('freetype2', version : '>= 12.0.6',
-                      fallback : ['freetype2', 'freetype_dep'],
-                      default_options : ['png=disabled', 'bzip2=disabled',
-                                         'zlib=disabled', 'harfbuzz=disabled'])
+cc = meson.get_compiler('c')
+
+# FreeType version ([libtool,    actual] from its docs/VERSIONS.TXT)
+#                  ([pkg-config, cmake])
+freetype_version = ['12.0.6', '2.4.2']
+
+# Set freetype as a dummy, for now
+freetype = dependency('', required: false)
+
+if cc.get_argument_syntax() == 'msvc'
+  freetype = dependency('freetype', version : '>= @0@'.format(freetype_version[1]),
+                        method: 'cmake',
+                        required: false)
+
+  if not freetype.found()
+    freetype_lib = cc.find_library('freetype',
+                                   has_headers: ['freetype/freetype.h'],
+                                   required: false)
+    if cc.has_function('FT_Reference_Face', dependencies : freetype_lib)
+      freetype = freetype_lib
+    else
+      message('Your FreeType2 installation is too old, falling back...')
+    endif
+  endif
+endif
+
+if not freetype.found()
+  freetype = dependency('freetype2', version : '>= @0@'.format(freetype_version[0]),
+                        method: 'pkg-config',
+                        fallback : ['freetype2', 'freetype_dep'],
+                        default_options : ['png=disabled', 'bzip2=disabled',
+                                           'zlib=disabled', 'harfbuzz=disabled'])
+endif
+
 harfbuzz = dependency('harfbuzz', version : '>= 1.7.2',
                       fallback : ['harfbuzz', 'libharfbuzz_dep'],
                       default_options : ['freetype=enabled',

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,12 @@ if harfbuzz.type_name() == 'internal' or \
   cc.has_header_symbol('hb.h', 'HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', dependencies : harfbuzz)
   config_h.set('HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', 1)
 endif
+if cc.get_argument_syntax() == 'msvc'
+  library_type = get_option('default_library')
+  if library_type == 'shared' or library_type == 'both'
+    config_h.set('RAQM_API', '__declspec (dllexport)')
+  endif
+endif
 configure_file(output : 'config.h', configuration : config_h)
 
 version_h = configuration_data()

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,7 +30,13 @@ version_h.set('RAQM_VERSION', meson.project_version())
 configure_file(
   input : 'raqm-version.h.in',
   output : 'raqm-version.h',
-  configuration : version_h)
+  configuration : version_h,
+  install: true,
+  install_dir: join_paths(get_option('includedir'))
+)
+
+raqm_headers = files('raqm.h')
+install_headers(raqm_headers)
 
 libraqm = library(
   'raqm',

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -30,6 +30,10 @@
 #include "config.h"
 #endif
 
+#ifndef RAQM_API
+#define RAQM_API
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <ft2build.h>
@@ -93,86 +97,86 @@ typedef struct raqm_glyph_t {
     FT_Face ftface;
 } raqm_glyph_t;
 
-raqm_t *
+RAQM_API raqm_t *
 raqm_create (void);
 
-raqm_t *
+RAQM_API raqm_t *
 raqm_reference (raqm_t *rq);
 
-void
+RAQM_API void
 raqm_destroy (raqm_t *rq);
 
-bool
+RAQM_API bool
 raqm_set_text (raqm_t         *rq,
                const uint32_t *text,
                size_t          len);
 
-bool
+RAQM_API bool
 raqm_set_text_utf8 (raqm_t     *rq,
                     const char *text,
                     size_t      len);
 
-bool
+RAQM_API bool
 raqm_set_par_direction (raqm_t          *rq,
                         raqm_direction_t dir);
 
-bool
+RAQM_API bool
 raqm_set_language (raqm_t       *rq,
                    const char   *lang,
                    size_t        start,
                    size_t        len);
 
-bool
+RAQM_API bool
 raqm_add_font_feature  (raqm_t     *rq,
                         const char *feature,
                         int         len);
 
-bool
+RAQM_API bool
 raqm_set_freetype_face (raqm_t *rq,
                         FT_Face face);
 
-bool
+RAQM_API bool
 raqm_set_freetype_face_range (raqm_t *rq,
                               FT_Face face,
                               size_t  start,
                               size_t  len);
 
-bool
+RAQM_API bool
 raqm_set_freetype_load_flags (raqm_t *rq,
                               int flags);
 
-bool
+RAQM_API bool
 raqm_set_invisible_glyph (raqm_t *rq,
                           int gid);
 
-bool
+RAQM_API bool
 raqm_layout (raqm_t *rq);
 
-raqm_glyph_t *
+RAQM_API raqm_glyph_t *
 raqm_get_glyphs (raqm_t *rq,
                  size_t *length);
 
-bool
+RAQM_API bool
 raqm_index_to_position (raqm_t *rq,
                         size_t *index,
                         int *x,
                         int *y);
 
-bool
+RAQM_API bool
 raqm_position_to_index (raqm_t *rq,
                         int x,
                         int y,
                         size_t *index);
 
-void
+RAQM_API void
 raqm_version (unsigned int *major,
               unsigned int *minor,
               unsigned int *micro);
 
-const char *
+RAQM_API const char *
 raqm_version_string (void);
 
-bool
+RAQM_API bool
 raqm_version_atleast (unsigned int major,
                       unsigned int minor,
                       unsigned int micro);


### PR DESCRIPTION
Hi,

This attempts to improve the libraqm/Meson build files with the following items:

*  Install the library headers.
*  Make Visual Studio shared library builds work
*  Improve FreeType2 depedency search for Visual Studio-style builds.  I started by looking for CMake config files, and then go back to manual searching.  If you prefer, as in HarfBuzz, I can drop the CMake searching and use the manual method only as FreeType2 had pretty weird versioning schemes between the ones used in their pkg-config file and their CMake config files.

I did not attempt fixing running the test programs with Meson for this PR, though.

The only updates to the source files was to update `raqm.h` to decorate the symbols with `RAQM_API`.

With blessings, thank you! 