### PR TITLE
Don't hardcode python3 in tests

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-python3 = import('python').find_installation('python3')
+python3 = import('python').find_installation()
 
 raqm_test = executable(
   'raqm-test',


### PR DESCRIPTION
Not all distributions calls python 3.x's binary python3, use the same executable as meson uses instead