### PR TITLE
Stability fixes for raqm object reusing

### DIFF
--- a/docs/raqm-sections.txt
+++ b/docs/raqm-sections.txt
@@ -3,6 +3,7 @@
 raqm_create
 raqm_reference
 raqm_destroy
+raqm_clear_contents
 raqm_set_text
 raqm_set_text_utf8
 raqm_set_par_direction

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ cc = meson.get_compiler('c')
 
 # FreeType version ([libtool,    actual] from its docs/VERSIONS.TXT)
 #                  ([pkg-config, cmake])
-freetype_version = ['12.0.6', '2.4.2']
+freetype_version = ['24.0.18', '2.11.0']
 
 # Set freetype as a dummy, for now
 freetype = dependency('', required: false)
@@ -42,7 +42,7 @@ if not freetype.found()
                                            'zlib=disabled', 'harfbuzz=disabled'])
 endif
 
-harfbuzz = dependency('harfbuzz', version : '>= 1.7.2',
+harfbuzz = dependency('harfbuzz', version : '>= 3.0.0',
                       fallback : ['harfbuzz', 'libharfbuzz_dep'],
                       default_options : ['freetype=enabled',
                                          'glib=disabled', 'gobject=disabled',
@@ -55,7 +55,7 @@ if get_option('sheenbidi')
   sheenbidi = dependency('sheenbidi',
                          fallback : ['sheenbidi', 'sheenbidi_dep'])
 else
-  fribidi = dependency('fribidi',
+  fribidi = dependency('fribidi',  version : '>= 1.0.6',
                        fallback : ['fribidi', 'libfribidi_dep'],
                        default_options : ['docs=false', 'tests=false'])
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,18 +1,6 @@
 cc = meson.get_compiler('c')
 
 config_h = configuration_data()
-if freetype.type_name() == 'internal' or \
-  cc.has_function('FT_Get_Transform', dependencies : freetype)
-  config_h.set('HAVE_FT_GET_TRANSFORM', 1)
-endif
-if harfbuzz.type_name() == 'internal' or \
-  cc.has_function('hb_buffer_set_invisible_glyph', dependencies : harfbuzz)
-  config_h.set('HAVE_HB_BUFFER_SET_INVISIBLE_GLYPH', 1)
-endif
-if harfbuzz.type_name() == 'internal' or \
-  cc.has_header_symbol('hb.h', 'HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', dependencies : harfbuzz)
-  config_h.set('HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', 1)
-endif
 if cc.get_argument_syntax() == 'msvc'
   library_type = get_option('default_library')
   if library_type == 'shared' or library_type == 'both'

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -398,6 +398,33 @@ raqm_destroy (raqm_t *rq)
   free (rq);
 }
 
+static bool
+_raqm_set_text_utf32(raqm_t         *rq,
+                     const uint32_t *text,
+                     size_t          len)
+{
+  /* Empty string, don’t fail but do nothing */
+  if (!len)
+    return true;
+
+  rq->text_len = len;
+
+  rq->text = malloc (sizeof (uint32_t) * rq->text_len);
+  if (!rq->text)
+    return false;
+
+  if (!_raqm_init_text_info (rq))
+  {
+    free (rq->text);
+    rq->text = NULL;
+    return false;
+  }
+
+  memcpy (rq->text, text, sizeof (uint32_t) * rq->text_len);
+
+  return true;
+}
+
 /**
  * raqm_set_text:
  * @rq: a #raqm_t.
@@ -426,26 +453,7 @@ raqm_set_text (raqm_t         *rq,
   _raqm_free_intermediate_data (rq);
   _raqm_init_intermediate_data (rq);
 
-  /* Empty string, don’t fail but do nothing */
-  if (!len)
-    return true;
-
-  rq->text_len = len;
-
-  rq->text = malloc (sizeof (uint32_t) * rq->text_len);
-  if (!rq->text)
-    return false;
-
-  if (!_raqm_init_text_info (rq))
-  {
-    free (rq->text);
-    rq->text = NULL;
-    return false;
-  }
-
-  memcpy (rq->text, text, sizeof (uint32_t) * rq->text_len);
-
-  return true;
+  return _raqm_set_text_utf32 (rq, text, len);
 }
 
 static void *
@@ -543,7 +551,7 @@ raqm_set_text_utf8 (raqm_t         *rq,
   memcpy (rq->text_utf8, text, sizeof (char) * len);
 
   ulen = _raqm_u8_to_u32 (text, len, unicode);
-  ok = raqm_set_text (rq, unicode, ulen);
+  ok = _raqm_set_text_utf32 (rq, unicode, ulen);
 
   if (ok)
   {

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -106,6 +106,9 @@ raqm_reference (raqm_t *rq);
 RAQM_API void
 raqm_destroy (raqm_t *rq);
 
+RAQM_API void
+raqm_clear_contents (raqm_t *rq);
+
 RAQM_API bool
 raqm_set_text (raqm_t         *rq,
                const uint32_t *text,

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=harfbuzz
 url=https://github.com/harfbuzz/harfbuzz.git
-revision=2.9.0
+revision=3.0.0

--- a/tests/cursor-position-GB8a.test
+++ b/tests/cursor-position-GB8a.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/bcb3b98eb67ece19b8b709f77143d91bcb3d95eb.ttf
 🇦🇧🇨🇩
---cluster 1 --position 1000 --require HB_020900
+--cluster 1 --position 1000
 Direction is: DEFAULT
 
 Before script detection:

--- a/tests/direction-ttb-1.test
+++ b/tests/direction-ttb-1.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/788742748bf8bfbd3b6b56859f92938275da74bd.otf
 汉语English
---direction ttb --require FT_020800
+--direction ttb
 Direction is: TTB
 
 Before script detection:

--- a/tests/direction-ttb-2.test
+++ b/tests/direction-ttb-2.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/788742748bf8bfbd3b6b56859f92938275da74bd.otf
 汉语English عربي
---direction ttb --require FT_020800
+--direction ttb
 Direction is: TTB
 
 Before script detection:

--- a/tests/invisible-glyph-explicit.test
+++ b/tests/invisible-glyph-explicit.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/e4c7989e4c78dc2af43fd87ede6a6ba6cbf14cb5.ttf
 芦󠄂
---direction ltr --invisible-glyph 33333 --require HB_010901
+--direction ltr --invisible-glyph 33333
 Direction is: LTR
 
 Before script detection:

--- a/tests/invisible-glyph-hidden.test
+++ b/tests/invisible-glyph-hidden.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/e4c7989e4c78dc2af43fd87ede6a6ba6cbf14cb5.ttf
 芦󠄂
---direction ltr --invisible-glyph -1 --require HB_010800
+--direction ltr --invisible-glyph -1
 Direction is: LTR
 
 Before script detection:


### PR DESCRIPTION
This PR addresses a couple of issues:

1. Reusing the same `raqm_t` with subsequent `raqm_set_text*` now works as expected. Previously it has been silently returning nonsense to an user.
2. Failed calls or zero length input to `raqm_set_text*` now free unnecessary memory.
3. Signed/unsgned mismatch warning is fixed (more of "silenced" than "fixed", run pos & length may need to be `size_t` instead of casting `index` to `int`).