### PR TITLE
Raise the minimum versions of dependencies

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ cc = meson.get_compiler('c')
 
 # FreeType version ([libtool,    actual] from its docs/VERSIONS.TXT)
 #                  ([pkg-config, cmake])
-freetype_version = ['12.0.6', '2.4.2']
+freetype_version = ['24.0.18', '2.11.0']
 
 # Set freetype as a dummy, for now
 freetype = dependency('', required: false)
@@ -42,7 +42,7 @@ if not freetype.found()
                                            'zlib=disabled', 'harfbuzz=disabled'])
 endif
 
-harfbuzz = dependency('harfbuzz', version : '>= 1.7.2',
+harfbuzz = dependency('harfbuzz', version : '>= 3.0.0',
                       fallback : ['harfbuzz', 'libharfbuzz_dep'],
                       default_options : ['freetype=enabled',
                                          'glib=disabled', 'gobject=disabled',
@@ -55,7 +55,7 @@ if get_option('sheenbidi')
   sheenbidi = dependency('sheenbidi',
                          fallback : ['sheenbidi', 'sheenbidi_dep'])
 else
-  fribidi = dependency('fribidi',
+  fribidi = dependency('fribidi',  version : '>= 1.0.6',
                        fallback : ['fribidi', 'libfribidi_dep'],
                        default_options : ['docs=false', 'tests=false'])
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,18 +1,6 @@
 cc = meson.get_compiler('c')
 
 config_h = configuration_data()
-if freetype.type_name() == 'internal' or \
-  cc.has_function('FT_Get_Transform', dependencies : freetype)
-  config_h.set('HAVE_FT_GET_TRANSFORM', 1)
-endif
-if harfbuzz.type_name() == 'internal' or \
-  cc.has_function('hb_buffer_set_invisible_glyph', dependencies : harfbuzz)
-  config_h.set('HAVE_HB_BUFFER_SET_INVISIBLE_GLYPH', 1)
-endif
-if harfbuzz.type_name() == 'internal' or \
-  cc.has_header_symbol('hb.h', 'HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', dependencies : harfbuzz)
-  config_h.set('HAVE_DECL_HB_BUFFER_FLAG_REMOVE_DEFAULT_IGNORABLES', 1)
-endif
 if cc.get_argument_syntax() == 'msvc'
   library_type = get_option('default_library')
   if library_type == 'shared' or library_type == 'both'

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=harfbuzz
 url=https://github.com/harfbuzz/harfbuzz.git
-revision=2.9.0
+revision=3.0.0

--- a/tests/cursor-position-GB8a.test
+++ b/tests/cursor-position-GB8a.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/bcb3b98eb67ece19b8b709f77143d91bcb3d95eb.ttf
 🇦🇧🇨🇩
---cluster 1 --position 1000 --require HB_020900
+--cluster 1 --position 1000
 Direction is: DEFAULT
 
 Before script detection:

--- a/tests/direction-ttb-1.test
+++ b/tests/direction-ttb-1.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/788742748bf8bfbd3b6b56859f92938275da74bd.otf
 汉语English
---direction ttb --require FT_020800
+--direction ttb
 Direction is: TTB
 
 Before script detection:

--- a/tests/direction-ttb-2.test
+++ b/tests/direction-ttb-2.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/788742748bf8bfbd3b6b56859f92938275da74bd.otf
 汉语English عربي
---direction ttb --require FT_020800
+--direction ttb
 Direction is: TTB
 
 Before script detection:

--- a/tests/invisible-glyph-explicit.test
+++ b/tests/invisible-glyph-explicit.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/e4c7989e4c78dc2af43fd87ede6a6ba6cbf14cb5.ttf
 芦󠄂
---direction ltr --invisible-glyph 33333 --require HB_010901
+--direction ltr --invisible-glyph 33333
 Direction is: LTR
 
 Before script detection:

--- a/tests/invisible-glyph-hidden.test
+++ b/tests/invisible-glyph-hidden.test
@@ -1,6 +1,6 @@
 fonts/sha1sum/e4c7989e4c78dc2af43fd87ede6a6ba6cbf14cb5.ttf
 芦󠄂
---direction ltr --invisible-glyph -1 --require HB_010800
+--direction ltr --invisible-glyph -1
 Direction is: LTR
 
 Before script detection:


### PR DESCRIPTION
We have quite a bit of functionality that is conditionally built based on versions of various dependencies. This is causing issues like: https://github.com/libgd/libgd/issues/790

So I think it is time to raise the minimum versions of our dependencies to avoid all such conditional behaviours.