### PR TITLE
Raqm object reusing

### DIFF
--- a/docs/raqm-sections.txt
+++ b/docs/raqm-sections.txt
@@ -3,6 +3,7 @@
 raqm_create
 raqm_reference
 raqm_destroy
+raqm_clear_contents
 raqm_set_text
 raqm_set_text_utf8
 raqm_set_par_direction

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -411,8 +411,8 @@ raqm_destroy (raqm_t *rq)
  * raqm_clear_contents:
  * @rq: a #raqm_t.
  *
- * Clears internal state of previously used raqm_t object, making it
- * ready for reuse.
+ * Clears internal state of previously used raqm_t object, making it ready
+ * for reuse and keeping some of allocated memory to increase performance.
  *
  * Since: 0.9
  */

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -410,7 +410,6 @@ raqm_destroy (raqm_t *rq)
 /**
  * raqm_clear_contents:
  * @rq: a #raqm_t.
- * @free_memory: whether to free internal buffers or to keep them for reuse.
  *
  * Clears internal state of previously used raqm_t object, making it
  * ready for reuse.
@@ -418,22 +417,12 @@ raqm_destroy (raqm_t *rq)
  * Since: 0.9
  */
 void
-raqm_clear_contents (raqm_t *rq,
-                     bool    free_memory)
+raqm_clear_contents (raqm_t *rq)
 {
   if (!rq)
     return;
 
   _raqm_release_text_info (rq);
-
-  if (free_memory)
-  {
-    _raqm_free_text (rq);
-
-    free (rq->glyphs);
-    rq->glyphs = NULL;
-    rq->glyphs_capacity = 0;
-  }
 
   _raqm_free_runs (rq);
   rq->runs = NULL;

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -265,12 +265,12 @@ _raqm_compare_text_info (_raqm_text_info a,
 static void
 _raqm_free_text(raqm_t* rq)
 {
-    free(rq->text);
-    rq->text = NULL;
-    rq->text_info = NULL;
-    rq->text_utf8 = NULL;
-    rq->text_len = 0;
-    rq->text_capacity_bytes = 0;
+  free (rq->text);
+  rq->text = NULL;
+  rq->text_info = NULL;
+  rq->text_utf8 = NULL;
+  rq->text_len = 0;
+  rq->text_capacity_bytes = 0;
 }
 
 static bool

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -107,7 +107,8 @@ RAQM_API void
 raqm_destroy (raqm_t *rq);
 
 RAQM_API void
-raqm_clear_contents (raqm_t *rq);
+raqm_clear_contents (raqm_t *rq,
+                     bool    free_memory);
 
 RAQM_API bool
 raqm_set_text (raqm_t         *rq,

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -107,8 +107,7 @@ RAQM_API void
 raqm_destroy (raqm_t *rq);
 
 RAQM_API void
-raqm_clear_contents (raqm_t *rq,
-                     bool    free_memory);
+raqm_clear_contents (raqm_t *rq);
 
 RAQM_API bool
 raqm_set_text (raqm_t         *rq,

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -106,6 +106,9 @@ raqm_reference (raqm_t *rq);
 RAQM_API void
 raqm_destroy (raqm_t *rq);
 
+RAQM_API void
+raqm_clear_contents (raqm_t *rq);
+
 RAQM_API bool
 raqm_set_text (raqm_t         *rq,
                const uint32_t *text,


### PR DESCRIPTION
This PR addresses a couple of issues:
1. Reusing the same `raqm_t` with subsequent `raqm_set_text*` now works if you call `raqm_clear_contents` in between. Previously it has been silently returning nonsense to an user.
2. Memory allocated inside `raqm_t` can be partially reused now.
3. Signed/unsgned mismatch warning is fixed (more of "silenced" than "fixed", run pos & length may need to be size_t instead of casting index to int).
4. UTF8 flag is removed as redundant. Checking rq->text_utf8 is enough and is at the same time safer.

This is a cleaner version of https://github.com/HOST-Oman/libraqm/pull/147
This should fix https://github.com/HOST-Oman/libraqm/issues/128