### PR TITLE
strdup is a posix extension, to be used correctly that has to be defi…

### DIFF
--- a/tests/raqm-test.c
+++ b/tests/raqm-test.c
@@ -21,7 +21,9 @@
  * SOFTWARE.
  *
  */
-
+#ifdef __GNUC__ 
+#define  _DEFAULT_SOURCE
+#endif
 #include <assert.h>
 #include <errno.h>
 #include <locale.h>


### PR DESCRIPTION
strdup is a posix extension, to be used correctly that has to be defined (only used here, no need to pass as -D