### PR TITLE
Implement set_text_utf16.

### DIFF
--- a/docs/raqm-docs.xml
+++ b/docs/raqm-docs.xml
@@ -51,7 +51,7 @@
     <xi:include href="xml/api-index-0.9.xml"/>
   </index>
   <index id="api-index-0-10" role="0.10">
-    <title>Index of new symbols in 0.9.x</title>
+    <title>Index of new symbols in 0.10.x</title>
     <xi:include href="xml/api-index-0.10.xml"/>
   </index>
   <!--index id="deprecated-api-index" role="deprecated">

--- a/docs/raqm-docs.xml
+++ b/docs/raqm-docs.xml
@@ -50,6 +50,10 @@
     <title>Index of new symbols in 0.9.x</title>
     <xi:include href="xml/api-index-0.9.xml"/>
   </index>
+  <index id="api-index-0-10" role="0.10">
+    <title>Index of new symbols in 0.9.x</title>
+    <xi:include href="xml/api-index-0.10.xml"/>
+  </index>
   <!--index id="deprecated-api-index" role="deprecated">
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"/>

--- a/docs/raqm-sections.txt
+++ b/docs/raqm-sections.txt
@@ -6,6 +6,7 @@ raqm_destroy
 raqm_clear_contents
 raqm_set_text
 raqm_set_text_utf8
+raqm_set_text_utf16
 raqm_set_par_direction
 raqm_set_language
 raqm_set_freetype_face

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -118,6 +118,10 @@ RAQM_API bool
 raqm_set_text_utf8 (raqm_t     *rq,
                     const char *text,
                     size_t      len);
+RAQM_API bool
+raqm_set_text_utf16 (raqm_t     *rq,
+                    const uint16_t *text,
+                    size_t      len);
 
 RAQM_API bool
 raqm_set_par_direction (raqm_t          *rq,


### PR DESCRIPTION
Hi,

I'm rewriting the [svg text layout for Krita](https://invent.kde.org/graphics/krita/-/merge_requests/1403), using libraqm as a base. I've gotten pretty far with it, however there's a number of smaller things that make more sense to implement in raqm itself.

The first of these is that our toolkit, Qt, uses utf16 for the strings by default, and while I can convert the strings to utf8 or utf32, keeping track of the string length and which encoding it's in is a bit of a drag, especially as raqm is already doing that for utf8. So I implemented utf16 functions in addition to the utf8 ones.

I had a bit of trouble deciding on how to tackle the tests. Right now, it seems the tests are always testing utf8? Any idea on how to approach this?