### PR TITLE
Baseline alignment

### DIFF
--- a/docs/raqm-sections.txt
+++ b/docs/raqm-sections.txt
@@ -13,6 +13,8 @@ raqm_set_freetype_face
 raqm_set_freetype_face_range
 raqm_set_freetype_load_flags
 raqm_set_freetype_load_flags_range
+raqm_set_baseline_tag_range
+raqm_set_baseline_shift_range
 raqm_set_invisible_glyph
 raqm_add_font_feature
 raqm_layout

--- a/meson.build
+++ b/meson.build
@@ -43,7 +43,7 @@ if not freetype.found()
                                            'zlib=disabled', 'harfbuzz=disabled'])
 endif
 
-harfbuzz = dependency('harfbuzz', version : '>= 3.0.0',
+harfbuzz = dependency('harfbuzz', version : '>= 4.0.0',
                       fallback : ['harfbuzz', 'libharfbuzz_dep'],
                       default_options : ['freetype=enabled',
                                          'glib=disabled', 'gobject=disabled',

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -159,6 +159,18 @@ raqm_set_freetype_load_flags_range (raqm_t *rq,
                                     size_t  len);
 
 RAQM_API bool
+raqm_set_baseline_tag_range(raqm_t *rq,
+                            const char* baseline_tag,
+                            size_t start,
+                            size_t len);
+
+RAQM_API bool
+raqm_set_baseline_shift_range(raqm_t *rq,
+                              int shift,
+                              size_t start,
+                              size_t len);
+
+RAQM_API bool
 raqm_set_invisible_glyph (raqm_t *rq,
                           int gid);
 

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=harfbuzz
 url=https://github.com/harfbuzz/harfbuzz.git
-revision=3.0.0
+revision=4.0.0

--- a/tests/baselines.test
+++ b/tests/baselines.test
@@ -1,0 +1,36 @@
+fonts/sha1sum/db17d357d9d813a863c3859d2f3af11faa0b39c7.ttf
+тбтб
+--direction ltr --baselines hang,0,4,romn,4,4 --require HB_040000
+Direction is: LTR
+
+Before script detection:
+script for ch[0]	Cyrl
+script for ch[1]	Cyrl
+script for ch[2]	Cyrl
+script for ch[3]	Cyrl
+
+After script detection:
+script for ch[0]	Cyrl
+script for ch[1]	Cyrl
+script for ch[2]	Cyrl
+script for ch[3]	Cyrl
+
+Number of runs before script itemization: 1
+
+BiDi Runs:
+run[0]:	 start: 0	length: 4	level: 0
+
+Number of runs after script itemization: 2
+
+Final Runs:
+run[0]:	 start: 0	length: 2	direction: ltr	script: Cyrl	font: DejaVu Serif
+run[1]:	 start: 2	length: 2	direction: ltr	script: Cyrl	font: DejaVu Serif
+
+Glyph information:
+glyph [3]	x_offset: 0	y_offset: 1228	x_advance: 1942	font: DejaVu Serif
+glyph [2]	x_offset: 0	y_offset: 1228	x_advance: 1250	font: DejaVu Serif
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 1942	font: DejaVu Serif
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 1250	font: DejaVu Serif
+
+UTF-32 clusters: 00 01 02 03
+UTF-8 clusters:  00 02 04 06

--- a/tests/baselines.test
+++ b/tests/baselines.test
@@ -27,8 +27,8 @@ run[0]:	 start: 0	length: 2	direction: ltr	script: Cyrl	font: DejaVu Serif
 run[1]:	 start: 2	length: 2	direction: ltr	script: Cyrl	font: DejaVu Serif
 
 Glyph information:
-glyph [3]	x_offset: 0	y_offset: 1228	x_advance: 1942	font: DejaVu Serif
-glyph [2]	x_offset: 0	y_offset: 1228	x_advance: 1250	font: DejaVu Serif
+glyph [3]	x_offset: 0	y_offset: -1228	x_advance: 1942	font: DejaVu Serif
+glyph [2]	x_offset: 0	y_offset: -1228	x_advance: 1250	font: DejaVu Serif
 glyph [3]	x_offset: 0	y_offset: 0	x_advance: 1942	font: DejaVu Serif
 glyph [2]	x_offset: 0	y_offset: 0	x_advance: 1250	font: DejaVu Serif
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -11,6 +11,7 @@ raqm_test = executable(
 
 tests = [
   'buffer-flags-1.test',
+  'baselines.test',
   'cursor-position-1.test',
   'cursor-position-2.test',
   'cursor-position-3.test',

--- a/tests/raqm-test.c
+++ b/tests/raqm-test.c
@@ -40,6 +40,7 @@ static char *languages = NULL;
 static char *direction = NULL;
 static char *features = NULL;
 static char *require = NULL;
+static char *baselines = NULL;
 static int cluster = -1;
 static int position = -1;
 static int invisible_glyph = 0;
@@ -100,6 +101,8 @@ parse_args (int argc, char **argv)
       direction = argv[++i];
     else if (strcmp (argv[i], "--font-features") == 0)
       features = argv[++i];
+    else if (strcmp (argv[i], "--baselines") == 0)
+      baselines = argv[++i];
     else if (strcmp (argv[i], "--require") == 0)
       require = argv[++i];
     else if (strcmp (argv[i], "--cluster") == 0)
@@ -226,6 +229,17 @@ main (int argc, char **argv)
   {
     for (char *tok = strtok (features, ","); tok; tok = strtok (NULL, ","))
       assert (raqm_add_font_feature (rq, tok, -1));
+  }
+  
+  if (baselines)
+  {
+    for (char *tok = strtok (baselines, ","); tok; tok = strtok (NULL, ","))
+    {
+      int start, length;
+      start = atoi (strtok (NULL, ","));
+      length = atoi (strtok (NULL, ","));
+      assert (raqm_set_baseline_tag_range (rq, tok, start, length));
+    }
   }
 
   if (invisible_glyph)


### PR DESCRIPTION
This implements set_baseline_tag_range and set_baseline_shift. This patch is build on top of https://github.com/HOST-Oman/libraqm/pull/165 .

The former can use opentype tags like "romn" and "hang", while the latter uses FreeType Font Units, and both values get added to the offset, depending on the direction.

I am not sure if offset is the correct place to add these values, as perhaps that makes it harder to align the caret properly.

Similarly, I am wondering about whether specific baseline-shift for super and sub are still useful here, or whether I should calculate these myself (given they need a font different than the current one to be correct).

Fix #167