### PR TITLE
Letter and word spacing

### DIFF
--- a/docs/raqm-sections.txt
+++ b/docs/raqm-sections.txt
@@ -13,6 +13,8 @@ raqm_set_freetype_face
 raqm_set_freetype_face_range
 raqm_set_freetype_load_flags
 raqm_set_freetype_load_flags_range
+raqm_set_letter_spacing_range
+raqm_set_word_spacing_range
 raqm_set_invisible_glyph
 raqm_add_font_feature
 raqm_layout

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -2168,16 +2168,25 @@ _raqm_shape (raqm_t *rq)
         _raqm_ft_transform (&pos[i].x_advance, &pos[i].y_advance, matrix);
         _raqm_ft_transform (&pos[i].x_offset, &pos[i].y_offset, matrix);
 
-        bool set_spacing = i == len - 1;
-        if (!set_spacing)
-          set_spacing = info[i].cluster != info[i+1].cluster;
+        bool set_spacing = false;
+        if (run->direction == HB_DIRECTION_RTL)
+        {
+          set_spacing = i == 0;
+          if (!set_spacing)
+            set_spacing = info[i].cluster != info[i-1].cluster;
+        }
+        else {
+          set_spacing = i == len - 1;
+          if (!set_spacing)
+            set_spacing = info[i].cluster != info[i+1].cluster;
+        }
 
         _raqm_text_info rq_info = rq->text_info[info[i].cluster];
 
-        if (rq_info.spacing_after != 0)
+        if (rq_info.spacing_after != 0 && set_spacing)
         {
           
-          if (run->direction == HB_DIRECTION_TTB && set_spacing)
+          if (run->direction == HB_DIRECTION_TTB)
           {
             if (rq_info.spacing_is_percentage)
             {
@@ -2194,16 +2203,14 @@ _raqm_shape (raqm_t *rq)
             {
               int spacing = pos[i].x_advance * (rq_info.spacing_after * 0.01);
               pos[i].x_offset += spacing;
-              if (set_spacing)
-                pos[i].x_advance += spacing;
+              pos[i].x_advance += spacing;
             }
             else {
-              if (set_spacing)
-                pos[i].x_advance += rq_info.spacing_after;
+              pos[i].x_advance += rq_info.spacing_after;
               pos[i].x_offset += rq_info.spacing_after;
             }
           }
-          else if (set_spacing)
+          else
           {
             if (rq_info.spacing_is_percentage)
             {

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1086,32 +1086,35 @@ _raqm_set_spacing (raqm_t *rq,
 
   for (size_t i = start; i < end; i++)
   {
-    bool set_spacing = i == rq->text_len - 1;
+    bool set_spacing = i == 0;
     if (!set_spacing)
-      set_spacing = _raqm_allowed_grapheme_boundary (rq->text[i], rq->text[i + 1]);
+      set_spacing = _raqm_allowed_grapheme_boundary (rq->text[i-1], rq->text[i]);
 
-    if (word_spacing)
+    if (set_spacing)
     {
-      if (set_spacing)
+      if (word_spacing)
       {
-        /* CSS word seperators, word spacing is only applied on these.*/
-        if (rq->text[i] == 0x0020  || /* Space */
-            rq->text[i] == 0x00A0  || /* No Break Space */
-            rq->text[i] == 0x1361  || /* Ethiopic Word Space */
-            rq->text[i] == 0x10100 || /* Aegean Word Seperator Line */
-            rq->text[i] == 0x10101 || /* Aegean Word Seperator Dot */
-            rq->text[i] == 0x1039F || /* Ugaric Word Divider */
-            rq->text[i] == 0x1091F)   /* Phoenician Word Separator */
+        if (_raqm_allowed_grapheme_boundary (rq->text[i], rq->text[i+1]))
         {
-          rq->text_info[i].spacing_after = spacing;
-          rq->text_info[i].spacing_is_percentage = percentage;
+          /* CSS word seperators, word spacing is only applied on these.*/
+          if (rq->text[i] == 0x0020  || /* Space */
+              rq->text[i] == 0x00A0  || /* No Break Space */
+              rq->text[i] == 0x1361  || /* Ethiopic Word Space */
+              rq->text[i] == 0x10100 || /* Aegean Word Seperator Line */
+              rq->text[i] == 0x10101 || /* Aegean Word Seperator Dot */
+              rq->text[i] == 0x1039F || /* Ugaric Word Divider */
+              rq->text[i] == 0x1091F)   /* Phoenician Word Separator */
+          {
+            rq->text_info[i].spacing_after = spacing;
+            rq->text_info[i].spacing_is_percentage = percentage;
+          }
         }
       }
-    }
-    else
-    {
-      rq->text_info[i].spacing_after = spacing;
-      rq->text_info[i].spacing_is_percentage = percentage;
+      else
+      {
+        rq->text_info[i].spacing_after = spacing;
+        rq->text_info[i].spacing_is_percentage = percentage;
+      }
     }
   }
 
@@ -1167,6 +1170,15 @@ raqm_set_letter_spacing_range(raqm_t *rq,
     rq->features[rq->features_len - 1].start = start;
     rq->features[rq->features_len - 1].end = end;
     raqm_add_font_feature(rq, "-liga", 5);
+    rq->features[rq->features_len - 1].start = start;
+    rq->features[rq->features_len - 1].end = end;
+    raqm_add_font_feature(rq, "-hlig", 5);
+    rq->features[rq->features_len - 1].start = start;
+    rq->features[rq->features_len - 1].end = end;
+    raqm_add_font_feature(rq, "-dlig", 5);
+    rq->features[rq->features_len - 1].start = start;
+    rq->features[rq->features_len - 1].end = end;
+    raqm_add_font_feature(rq, "-calt", 5);
     rq->features[rq->features_len - 1].start = start;
     rq->features[rq->features_len - 1].end = end;
   }

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -220,6 +220,10 @@ static size_t
 _raqm_encoding_to_u32_index (raqm_t *rq,
                              size_t  index);
 
+static bool
+_raqm_allowed_grapheme_boundary (hb_codepoint_t l_char,
+                                hb_codepoint_t r_char);
+
 static void
 _raqm_init_text_info (raqm_t *rq)
 {
@@ -1060,19 +1064,6 @@ raqm_set_freetype_load_flags_range (raqm_t *rq,
   return _raqm_set_freetype_load_flags (rq, flags, start, end);
 }
 
-/* CSS  Word seperators, word spacing is only applied on these.*/
-static size_t word_separators_len = 7;
-static const uint32_t word_separators[] =
-{
-  0x0020,  /// Space
-  0x00A0,  /// No break space
-  0x1361,  /// Ethiopic word space
-  0x10100, /// Aegean wordspace
-  0x10101, /// Aegean wordspace
-  0x1039F, /// Ugaric word divider
-  0x1091F  /// Phoenician word separator
-};
-
 static bool
 _raqm_set_spacing (raqm_t *rq,
                    int    spacing,
@@ -1094,11 +1085,23 @@ _raqm_set_spacing (raqm_t *rq,
     return false;
 
   for (size_t i = start; i < end; i++)
+  {
+    bool set_spacing = i == rq->text_len - 1;
+    if (!set_spacing)
+      set_spacing = _raqm_allowed_grapheme_boundary (rq->text[i], rq->text[i + 1]);
+
     if (word_spacing)
     {
-      for (size_t j = 0; j < word_separators_len; j++)
+      if (set_spacing)
       {
-        if (rq->text[i] == word_separators[j])
+        /* CSS word seperators, word spacing is only applied on these.*/
+        if (rq->text[i] == 0x0020  || /* Space */
+            rq->text[i] == 0x00A0  || /* No Break Space */
+            rq->text[i] == 0x1361  || /* Ethiopic Word Space */
+            rq->text[i] == 0x10100 || /* Aegean Word Seperator Line */
+            rq->text[i] == 0x10101 || /* Aegean Word Seperator Dot */
+            rq->text[i] == 0x1039F || /* Ugaric Word Divider */
+            rq->text[i] == 0x1091F)   /* Phoenician Word Separator */
         {
           rq->text_info[i].spacing_after = spacing;
           rq->text_info[i].spacing_is_percentage = percentage;
@@ -1110,6 +1113,7 @@ _raqm_set_spacing (raqm_t *rq,
       rq->text_info[i].spacing_after = spacing;
       rq->text_info[i].spacing_is_percentage = percentage;
     }
+  }
 
   return true;
 }
@@ -1130,6 +1134,10 @@ _raqm_set_spacing (raqm_t *rq,
  * Note that not all scripts have a letter-spacing tradition,
  * for example, Arabic does not, while Devanagari does.
  *
+ * This will also add 'disable liga and clig' font features to the internal 
+ * features list, so call this function after setting the font features for
+ * best spacing results.
+ * 
  * Return value:
  * `true` if no errors happened, `false` otherwise.
  *
@@ -1142,7 +1150,7 @@ raqm_set_letter_spacing_range(raqm_t *rq,
                               size_t start,
                               size_t len)
 {
-  size_t end = start + (len-1);
+  size_t end;
 
   if (!rq)
     return false;
@@ -1150,15 +1158,17 @@ raqm_set_letter_spacing_range(raqm_t *rq,
   if (!rq->text_len)
     return true;
 
-  if (rq->text_utf8)
+  end = _raqm_encoding_to_u32_index (rq, start + len - 1);
+  start = _raqm_encoding_to_u32_index (rq, start);
+  
+  if (spacing != 0)
   {
-    start = _raqm_u8_to_u32_index (rq, start);
-    end = _raqm_u8_to_u32_index (rq, end);
-  }
-  else if (rq->text_utf16)
-  {
-    start = _raqm_u16_to_u32_index (rq, start);
-    end = _raqm_u16_to_u32_index (rq, end);
+    raqm_add_font_feature(rq, "-clig", 5);
+    rq->features[rq->features_len - 1].start = start;
+    rq->features[rq->features_len - 1].end = end;
+    raqm_add_font_feature(rq, "-liga", 5);
+    rq->features[rq->features_len - 1].start = start;
+    rq->features[rq->features_len - 1].end = end;
   }
 
   return _raqm_set_spacing (rq, spacing, percentage, false, start, end);
@@ -1191,7 +1201,7 @@ raqm_set_word_spacing_range(raqm_t *rq,
                             size_t start,
                             size_t len)
 {
-  size_t end = start + len;
+  size_t end;
 
   if (!rq)
     return false;
@@ -1199,16 +1209,8 @@ raqm_set_word_spacing_range(raqm_t *rq,
   if (!rq->text_len)
     return true;
 
-  if (rq->text_utf8)
-  {
-    start = _raqm_u8_to_u32_index (rq, start);
-    end = _raqm_u8_to_u32_index (rq, end);
-  }
-  else if (rq->text_utf16)
-  {
-    start = _raqm_u16_to_u32_index (rq, start);
-    end = _raqm_u16_to_u32_index (rq, end);
-  }
+  end = _raqm_encoding_to_u32_index (rq, start + len);
+  start = _raqm_encoding_to_u32_index (rq, start);
 
   return _raqm_set_spacing (rq, spacing, percentage, true, start, end);
 }
@@ -2160,45 +2162,55 @@ _raqm_shape (raqm_t *rq)
       FT_Get_Transform (hb_ft_font_get_face (run->font), &matrix, NULL);
       pos = hb_buffer_get_glyph_positions (run->buffer, &len);
       info = hb_buffer_get_glyph_infos (run->buffer, &len);
+
       for (unsigned int i = 0; i < len; i++)
       {
         _raqm_ft_transform (&pos[i].x_advance, &pos[i].y_advance, matrix);
         _raqm_ft_transform (&pos[i].x_offset, &pos[i].y_offset, matrix);
 
-        if (rq->text_info[info[i].cluster].spacing_after != 0)
+        bool set_spacing = i == len - 1;
+        if (!set_spacing)
+          set_spacing = info[i].cluster != info[i+1].cluster;
+
+        _raqm_text_info rq_info = rq->text_info[info[i].cluster];
+
+        if (rq_info.spacing_after != 0)
         {
-          if (run->direction == HB_DIRECTION_TTB)
+          
+          if (run->direction == HB_DIRECTION_TTB && set_spacing)
           {
-            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            if (rq_info.spacing_is_percentage)
             {
-              int spacing = pos[i].y_advance * (rq->text_info[info[i].cluster].spacing_after * 0.01);
+              int spacing = pos[i].y_advance * (rq_info.spacing_after * 0.01);
               pos[i].y_advance += spacing;
             }
             else {
-              pos[i].y_advance -= rq->text_info[info[i].cluster].spacing_after;
+              pos[i].y_advance -= rq_info.spacing_after;
             }
           }
           else if (run->direction == HB_DIRECTION_RTL)
           {
-            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            if (rq_info.spacing_is_percentage)
             {
-              int spacing = pos[i].x_advance * (rq->text_info[info[i].cluster].spacing_after * 0.01);
+              int spacing = pos[i].x_advance * (rq_info.spacing_after * 0.01);
               pos[i].x_offset += spacing;
-              pos[i].x_advance += spacing;
+              if (set_spacing)
+                pos[i].x_advance += spacing;
             }
             else {
-              pos[i].x_advance += rq->text_info[info[i].cluster].spacing_after;
-              pos[i].x_offset += rq->text_info[info[i].cluster].spacing_after;
+              if (set_spacing)
+                pos[i].x_advance += rq_info.spacing_after;
+              pos[i].x_offset += rq_info.spacing_after;
             }
           }
-          else
+          else if (set_spacing)
           {
-            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            if (rq_info.spacing_is_percentage)
             {
-              pos[i].x_advance *= 1.0 + (rq->text_info[info[i].cluster].spacing_after * 0.01);
+              pos[i].x_advance *= 1.0 + (rq_info.spacing_after * 0.01);
             }
             else {
-              pos[i].x_advance += rq->text_info[info[i].cluster].spacing_after;
+              pos[i].x_advance += rq_info.spacing_after;
             }
           }
         }
@@ -2324,10 +2336,6 @@ _raqm_encoding_to_u32_index (raqm_t *rq,
     return _raqm_u16_to_u32_index (rq, index);
   return index;
 }
-
-static bool
-_raqm_allowed_grapheme_boundary (hb_codepoint_t l_char,
-                                hb_codepoint_t r_char);
 
 static bool
 _raqm_in_hangul_syllable (hb_codepoint_t ch);

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -172,6 +172,8 @@ typedef struct {
   int           ftloadflags;
   hb_language_t lang;
   hb_script_t   script;
+  int           spacing_after;
+  bool          spacing_is_percentage;
 } _raqm_text_info;
 
 typedef struct _raqm_run raqm_run_t;
@@ -228,6 +230,8 @@ _raqm_init_text_info (raqm_t *rq)
     rq->text_info[i].ftloadflags = -1;
     rq->text_info[i].lang = default_lang;
     rq->text_info[i].script = HB_SCRIPT_INVALID;
+    rq->text_info[i].spacing_after = 0;
+    rq->text_info[i].spacing_is_percentage = false;
   }
 }
 
@@ -259,6 +263,8 @@ _raqm_compare_text_info (_raqm_text_info a,
 
   if (a.script != b.script)
     return false;
+
+  /* Spacing shouldn't break runs, so we don't compare them here. */
 
   return true;
 }
@@ -1052,6 +1058,159 @@ raqm_set_freetype_load_flags_range (raqm_t *rq,
   start = _raqm_encoding_to_u32_index (rq, start);
 
   return _raqm_set_freetype_load_flags (rq, flags, start, end);
+}
+
+/* CSS  Word seperators, word spacing is only applied on these.*/
+static size_t word_separators_len = 7;
+static const uint32_t word_separators[] =
+{
+  0x0020,  /// Space
+  0x00A0,  /// No break space
+  0x1361,  /// Ethiopic word space
+  0x10100, /// Aegean wordspace
+  0x10101, /// Aegean wordspace
+  0x1039F, /// Ugaric word divider
+  0x1091F  /// Phoenician word separator
+};
+
+static bool
+_raqm_set_spacing (raqm_t *rq,
+                   int    spacing,
+                   bool   percentage,
+                   bool   word_spacing,
+                   size_t start,
+                   size_t end)
+{
+  if (!rq)
+    return false;
+
+  if (!rq->text_len)
+    return true;
+
+  if (start >= rq->text_len || end > rq->text_len)
+    return false;
+
+  if (!rq->text_info)
+    return false;
+
+  for (size_t i = start; i < end; i++)
+    if (word_spacing)
+    {
+      for (size_t j = 0; j < word_separators_len; j++)
+      {
+        if (rq->text[i] == word_separators[j])
+        {
+          rq->text_info[i].spacing_after = spacing;
+          rq->text_info[i].spacing_is_percentage = percentage;
+        }
+      }
+    }
+    else
+    {
+      rq->text_info[i].spacing_after = spacing;
+      rq->text_info[i].spacing_is_percentage = percentage;
+    }
+
+  return true;
+}
+
+/**
+ * raqm_set_letter_spacing_range:
+ * @rq: a #raqm_t.
+ * @spacing: amount of spacing in Freetype Font Units (26.6 format), or percentages of the advance (0 - 100)
+ * @percentage: whether to interpret the @spacing amount as a percentage of
+ * the character advance.
+ * @start: index of first character that should use @spacing.
+ * @len: number of characters using @spacing.
+ * 
+ * Set the letter spacing or tracking for a given range, the value
+ * will be added onto the advance and offset for RTL, and the advance for
+ * other directions. Letter spacing will be applied between characters, so
+ * the last character will not have spacing applied after it.
+ * Note that not all scripts have a letter-spacing tradition,
+ * for example, Arabic does not, while Devanagari does.
+ *
+ * Return value:
+ * `true` if no errors happened, `false` otherwise.
+ *
+ * Since: 0.10 
+ */
+bool
+raqm_set_letter_spacing_range(raqm_t *rq,
+                              int    spacing,
+                              bool   percentage,
+                              size_t start,
+                              size_t len)
+{
+  size_t end = start + (len-1);
+
+  if (!rq)
+    return false;
+
+  if (!rq->text_len)
+    return true;
+
+  if (rq->text_utf8)
+  {
+    start = _raqm_u8_to_u32_index (rq, start);
+    end = _raqm_u8_to_u32_index (rq, end);
+  }
+  else if (rq->text_utf16)
+  {
+    start = _raqm_u16_to_u32_index (rq, start);
+    end = _raqm_u16_to_u32_index (rq, end);
+  }
+
+  return _raqm_set_spacing (rq, spacing, percentage, false, start, end);
+}
+
+/**
+ * raqm_set_word_spacing_range:
+ * @rq: a #raqm_t.
+ * @spacing: amount of spacing in Freetype Font Units (26.6 format), or percentages of the advance (0 - 100)
+ * @percentage: whether to interpret the @spacing amount as a percentage of
+ * the character advance.
+ * @start: index of first character that should use @spacing.
+ * @len: number of characters using @spacing.
+ * 
+ * Set the word spacing for a given range. Word spacing will only be applied to
+ * 'word separator' characters, such as 'space', 'no break space' and
+ * Ethiopic word separator'.
+ * The value will be added onto the advance and offset for RTL, and the advance
+ * for other directions.
+ *
+ * Return value:
+ * `true` if no errors happened, `false` otherwise.
+ *
+ * Since: 0.10 
+ */
+bool
+raqm_set_word_spacing_range(raqm_t *rq,
+                            int    spacing,
+                            bool   percentage,
+                            size_t start,
+                            size_t len)
+{
+  size_t end = start + len;
+
+  if (!rq)
+    return false;
+
+  if (!rq->text_len)
+    return true;
+
+  if (rq->text_utf8)
+  {
+    start = _raqm_u8_to_u32_index (rq, start);
+    end = _raqm_u8_to_u32_index (rq, end);
+  }
+  else if (rq->text_utf16)
+  {
+    start = _raqm_u16_to_u32_index (rq, start);
+    end = _raqm_u16_to_u32_index (rq, end);
+  }
+
+  return _raqm_set_spacing (rq, spacing, percentage, true, start, end);
 }
 
 /**
@@ -1994,15 +2153,56 @@ _raqm_shape (raqm_t *rq)
 
     {
       FT_Matrix matrix;
+      hb_glyph_info_t *info;
       hb_glyph_position_t *pos;
       unsigned int len;
 
       FT_Get_Transform (hb_ft_font_get_face (run->font), &matrix, NULL);
       pos = hb_buffer_get_glyph_positions (run->buffer, &len);
+      info = hb_buffer_get_glyph_infos (run->buffer, &len);
       for (unsigned int i = 0; i < len; i++)
       {
         _raqm_ft_transform (&pos[i].x_advance, &pos[i].y_advance, matrix);
         _raqm_ft_transform (&pos[i].x_offset, &pos[i].y_offset, matrix);
+
+        if (rq->text_info[info[i].cluster].spacing_after != 0)
+        {
+          if (run->direction == HB_DIRECTION_TTB)
+          {
+            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            {
+              int spacing = pos[i].y_advance * (rq->text_info[info[i].cluster].spacing_after * 0.01);
+              pos[i].y_advance += spacing;
+            }
+            else {
+              pos[i].y_advance -= rq->text_info[info[i].cluster].spacing_after;
+            }
+          }
+          else if (run->direction == HB_DIRECTION_RTL)
+          {
+            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            {
+              int spacing = pos[i].x_advance * (rq->text_info[info[i].cluster].spacing_after * 0.01);
+              pos[i].x_offset += spacing;
+              pos[i].x_advance += spacing;
+            }
+            else {
+              pos[i].x_advance += rq->text_info[info[i].cluster].spacing_after;
+              pos[i].x_offset += rq->text_info[info[i].cluster].spacing_after;
+            }
+          }
+          else
+          {
+            if (rq->text_info[info[i].cluster].spacing_is_percentage)
+            {
+              pos[i].x_advance *= 1.0 + (rq->text_info[info[i].cluster].spacing_after * 0.01);
+            }
+            else {
+              pos[i].x_advance += rq->text_info[info[i].cluster].spacing_after;
+            }
+          }
+        }
+
       }
     }
   }

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -159,6 +159,19 @@ raqm_set_freetype_load_flags_range (raqm_t *rq,
                                     size_t  len);
 
 RAQM_API bool
+raqm_set_letter_spacing_range(raqm_t *rq,
+                              int    spacing,
+                              bool   percentage,
+                              size_t start,
+                              size_t len);
+RAQM_API bool
+raqm_set_word_spacing_range(raqm_t *rq,
+                            int    spacing,
+                            bool   percentage,
+                            size_t start,
+                            size_t len);
+
+RAQM_API bool
 raqm_set_invisible_glyph (raqm_t *rq,
                           int gid);
 

--- a/src/raqm.h
+++ b/src/raqm.h
@@ -161,13 +161,11 @@ raqm_set_freetype_load_flags_range (raqm_t *rq,
 RAQM_API bool
 raqm_set_letter_spacing_range(raqm_t *rq,
                               int    spacing,
-                              bool   percentage,
                               size_t start,
                               size_t len);
 RAQM_API bool
 raqm_set_word_spacing_range(raqm_t *rq,
                             int    spacing,
-                            bool   percentage,
                             size_t start,
                             size_t len);
 

--- a/tests/letter-and-wordspacing.test
+++ b/tests/letter-and-wordspacing.test
@@ -1,70 +1,105 @@
 fonts/sha1sum/d46a2549d27c32605024201abf801bb9a9273da3.ttf
-عربيעבריתأهلב ריתمم(ُeng lish ) مرحبا
---direction rtl --letterspacing 10,0,37 --wordspacing 50,0,37
- 
+وَرِقْE̽̿̎ͩͥ͊̚n̡̩͉̜̩͕ͨ̉ͩ̂̾ğ̞̭͙̰͍̽̆͝l̯̟̹̩̟͓̒̐ͫͥ̒̑͝i̷̲̪̳̝̓͌͊̍̚ş̍̒ͬ̅̅h̫ͥ z
+--direction rtl --letterspacing 10,0,72 --wordspacing 50,0,72
 Direction is: RTL
 
 Before script detection:
 script for ch[0]	Arab
-script for ch[1]	Arab
+script for ch[1]	Zinh
 script for ch[2]	Arab
-script for ch[3]	Arab
-script for ch[4]	Hebr
-script for ch[5]	Hebr
-script for ch[6]	Hebr
-script for ch[7]	Hebr
-script for ch[8]	Hebr
-script for ch[9]	Arab
-script for ch[10]	Arab
-script for ch[11]	Arab
-script for ch[12]	Hebr
-script for ch[13]	Zyyy
-script for ch[14]	Hebr
-script for ch[15]	Hebr
-script for ch[16]	Hebr
-script for ch[17]	Arab
-script for ch[18]	Arab
-script for ch[19]	Zyyy
+script for ch[3]	Zinh
+script for ch[4]	Arab
+script for ch[5]	Zinh
+script for ch[6]	Latn
+script for ch[7]	Zinh
+script for ch[8]	Zinh
+script for ch[9]	Zinh
+script for ch[10]	Zinh
+script for ch[11]	Zinh
+script for ch[12]	Zinh
+script for ch[13]	Zinh
+script for ch[14]	Latn
+script for ch[15]	Zinh
+script for ch[16]	Zinh
+script for ch[17]	Zinh
+script for ch[18]	Zinh
+script for ch[19]	Zinh
 script for ch[20]	Zinh
-script for ch[21]	Latn
-script for ch[22]	Latn
-script for ch[23]	Latn
-script for ch[24]	Zyyy
-script for ch[25]	Latn
+script for ch[21]	Zinh
+script for ch[22]	Zinh
+script for ch[23]	Zinh
+script for ch[24]	Zinh
+script for ch[25]	Zinh
 script for ch[26]	Latn
-script for ch[27]	Latn
-script for ch[28]	Latn
-script for ch[29]	Zyyy
-script for ch[30]	Zyyy
-script for ch[31]	Zyyy
-script for ch[32]	Arab
-script for ch[33]	Arab
-script for ch[34]	Arab
-script for ch[35]	Arab
-script for ch[36]	Arab
+script for ch[27]	Zinh
+script for ch[28]	Zinh
+script for ch[29]	Zinh
+script for ch[30]	Zinh
+script for ch[31]	Zinh
+script for ch[32]	Zinh
+script for ch[33]	Zinh
+script for ch[34]	Zinh
+script for ch[35]	Zinh
+script for ch[36]	Latn
+script for ch[37]	Zinh
+script for ch[38]	Zinh
+script for ch[39]	Zinh
+script for ch[40]	Zinh
+script for ch[41]	Zinh
+script for ch[42]	Zinh
+script for ch[43]	Zinh
+script for ch[44]	Zinh
+script for ch[45]	Zinh
+script for ch[46]	Zinh
+script for ch[47]	Zinh
+script for ch[48]	Zinh
+script for ch[49]	Zinh
+script for ch[50]	Latn
+script for ch[51]	Zinh
+script for ch[52]	Zinh
+script for ch[53]	Zinh
+script for ch[54]	Zinh
+script for ch[55]	Zinh
+script for ch[56]	Zinh
+script for ch[57]	Zinh
+script for ch[58]	Zinh
+script for ch[59]	Zinh
+script for ch[60]	Zinh
+script for ch[61]	Latn
+script for ch[62]	Zinh
+script for ch[63]	Zinh
+script for ch[64]	Zinh
+script for ch[65]	Zinh
+script for ch[66]	Zinh
+script for ch[67]	Zinh
+script for ch[68]	Latn
+script for ch[69]	Zinh
+script for ch[70]	Zinh
+script for ch[71]	Zyyy
+script for ch[72]	Latn
 
 After script detection:
 script for ch[0]	Arab
 script for ch[1]	Arab
 script for ch[2]	Arab
 script for ch[3]	Arab
-script for ch[4]	Hebr
-script for ch[5]	Hebr
-script for ch[6]	Hebr
-script for ch[7]	Hebr
-script for ch[8]	Hebr
-script for ch[9]	Arab
-script for ch[10]	Arab
-script for ch[11]	Arab
-script for ch[12]	Hebr
-script for ch[13]	Hebr
-script for ch[14]	Hebr
-script for ch[15]	Hebr
-script for ch[16]	Hebr
-script for ch[17]	Arab
-script for ch[18]	Arab
-script for ch[19]	Arab
-script for ch[20]	Arab
+script for ch[4]	Arab
+script for ch[5]	Arab
+script for ch[6]	Latn
+script for ch[7]	Latn
+script for ch[8]	Latn
+script for ch[9]	Latn
+script for ch[10]	Latn
+script for ch[11]	Latn
+script for ch[12]	Latn
+script for ch[13]	Latn
+script for ch[14]	Latn
+script for ch[15]	Latn
+script for ch[16]	Latn
+script for ch[17]	Latn
+script for ch[18]	Latn
+script for ch[19]	Latn
+script for ch[20]	Latn
 script for ch[21]	Latn
 script for ch[22]	Latn
 script for ch[23]	Latn
@@ -74,71 +109,136 @@ script for ch[26]	Latn
 script for ch[27]	Latn
 script for ch[28]	Latn
 script for ch[29]	Latn
-script for ch[30]	Arab
-script for ch[31]	Arab
-script for ch[32]	Arab
-script for ch[33]	Arab
-script for ch[34]	Arab
-script for ch[35]	Arab
-script for ch[36]	Arab
+script for ch[30]	Latn
+script for ch[31]	Latn
+script for ch[32]	Latn
+script for ch[33]	Latn
+script for ch[34]	Latn
+script for ch[35]	Latn
+script for ch[36]	Latn
+script for ch[37]	Latn
+script for ch[38]	Latn
+script for ch[39]	Latn
+script for ch[40]	Latn
+script for ch[41]	Latn
+script for ch[42]	Latn
+script for ch[43]	Latn
+script for ch[44]	Latn
+script for ch[45]	Latn
+script for ch[46]	Latn
+script for ch[47]	Latn
+script for ch[48]	Latn
+script for ch[49]	Latn
+script for ch[50]	Latn
+script for ch[51]	Latn
+script for ch[52]	Latn
+script for ch[53]	Latn
+script for ch[54]	Latn
+script for ch[55]	Latn
+script for ch[56]	Latn
+script for ch[57]	Latn
+script for ch[58]	Latn
+script for ch[59]	Latn
+script for ch[60]	Latn
+script for ch[61]	Latn
+script for ch[62]	Latn
+script for ch[63]	Latn
+script for ch[64]	Latn
+script for ch[65]	Latn
+script for ch[66]	Latn
+script for ch[67]	Latn
+script for ch[68]	Latn
+script for ch[69]	Latn
+script for ch[70]	Latn
+script for ch[71]	Latn
+script for ch[72]	Latn
 
-Number of runs before script itemization: 3
+Number of runs before script itemization: 2
 
 BiDi Runs:
-run[0]:	 start: 29	length: 8	level: 1
-run[1]:	 start: 21	length: 8	level: 2
-run[2]:	 start: 0	length: 21	level: 1
+run[0]:	 start: 6	length: 67	level: 2
+run[1]:	 start: 0	length: 6	level: 1
 
-Number of runs after script itemization: 8
+Number of runs after script itemization: 2
 
 Final Runs:
-run[0]:	 start: 30	length: 7	direction: rtl	script: Arab	font: DejaVu Sans
-run[1]:	 start: 29	length: 1	direction: rtl	script: Latn	font: DejaVu Sans
-run[2]:	 start: 21	length: 8	direction: ltr	script: Latn	font: DejaVu Sans
-run[3]:	 start: 17	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
-run[4]:	 start: 12	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
-run[5]:	 start: 9	length: 3	direction: rtl	script: Arab	font: DejaVu Sans
-run[6]:	 start: 4	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
-run[7]:	 start: 0	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
+run[0]:	 start: 6	length: 67	direction: ltr	script: Latn	font: DejaVu Sans
+run[1]:	 start: 0	length: 6	direction: rtl	script: Arab	font: DejaVu Sans
 
 Glyph information:
-glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	font: DejaVu Sans
-glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	font: DejaVu Sans
-glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	font: DejaVu Sans
-glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
-glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
-glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1239	font: DejaVu Sans
 glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1239	font: DejaVu Sans
 glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	font: DejaVu Sans
-glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1239	font: DejaVu Sans
 glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1239	font: DejaVu Sans
 glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
-glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	font: DejaVu Sans
-glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
-glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	font: DejaVu Sans
-glyph [50]	x_offset: 10	y_offset: 0	x_advance: 1107	font: DejaVu Sans
-glyph [15]	x_offset: 10	y_offset: 0	x_advance: 1356	font: DejaVu Sans
-glyph [12]	x_offset: 10	y_offset: 0	x_advance: 468	font: DejaVu Sans
-glyph [14]	x_offset: 10	y_offset: 0	x_advance: 1166	font: DejaVu Sans
-glyph [1]	x_offset: 50	y_offset: 0	x_advance: 701	font: DejaVu Sans
-glyph [11]	x_offset: 10	y_offset: 0	x_advance: 1194	font: DejaVu Sans
-glyph [46]	x_offset: 10	y_offset: 0	x_advance: 1561	font: DejaVu Sans
-glyph [53]	x_offset: 10	y_offset: 0	x_advance: 1090	font: DejaVu Sans
-glyph [16]	x_offset: 10	y_offset: 0	x_advance: 579	font: DejaVu Sans
-glyph [15]	x_offset: 10	y_offset: 0	x_advance: 1356	font: DejaVu Sans
-glyph [12]	x_offset: 10	y_offset: 0	x_advance: 468	font: DejaVu Sans
-glyph [14]	x_offset: 10	y_offset: 0	x_advance: 1166	font: DejaVu Sans
-glyph [11]	x_offset: 10	y_offset: 0	x_advance: 1194	font: DejaVu Sans
-glyph [13]	x_offset: 10	y_offset: 0	x_advance: 1292	font: DejaVu Sans
-glyph [56]	x_offset: 10	y_offset: 0	x_advance: 1717	font: DejaVu Sans
-glyph [37]	x_offset: 10	y_offset: 0	x_advance: 580	font: DejaVu Sans
-glyph [42]	x_offset: 10	y_offset: 0	x_advance: 1140	font: DejaVu Sans
-glyph [44]	x_offset: 10	y_offset: 0	x_advance: 1232	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1239	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [20]	x_offset: 10	y_offset: 0	x_advance: 999	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1239	font: DejaVu Sans
 
-UTF-32 clusters: 36 35 34 33 32 31 30 29 21 22 23 24 25 26 27 28 19 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
-UTF-8 clusters:  59 57 55 53 51 50 49 48 40 41 42 43 44 45 46 47 37 37 35 33 31 29 27 26 24 22 20 18 16 14 12 10 08 06 04 02 00
+UTF-32 clusters: 06 06 06 06 06 06 06 06 14 14 14 14 14 14 14 14 14 14 14 14 26 26 26 26 26 26 26 26 26 26 36 36 36 36 36 36 36 36 36 36 36 36 36 36 50 50 50 50 50 50 50 50 50 50 50 61 61 61 61 61 61 61 68 68 68 71 72 04 04 02 02 00 00
+UTF-8 clusters:  12 12 12 12 12 12 12 12 27 27 27 27 27 27 27 27 27 27 27 27 50 50 50 50 50 50 50 50 50 50 69 69 69 69 69 69 69 69 69 69 69 69 69 69 96 96 96 96 96 96 96 96 96 96 96 117 117 117 117 117 117 117 130 130 130 135 136 08 08 04 04 00 00

--- a/tests/letter-and-wordspacing.test
+++ b/tests/letter-and-wordspacing.test
@@ -1,0 +1,144 @@
+fonts/sha1sum/d46a2549d27c32605024201abf801bb9a9273da3.ttf
+عربيעבריתأهلב ריתمم(ُeng lish ) مرحبا
+--direction rtl --letterspacing 10,0,37 --wordspacing 50,0,37
+ 
+Direction is: RTL
+
+Before script detection:
+script for ch[0]	Arab
+script for ch[1]	Arab
+script for ch[2]	Arab
+script for ch[3]	Arab
+script for ch[4]	Hebr
+script for ch[5]	Hebr
+script for ch[6]	Hebr
+script for ch[7]	Hebr
+script for ch[8]	Hebr
+script for ch[9]	Arab
+script for ch[10]	Arab
+script for ch[11]	Arab
+script for ch[12]	Hebr
+script for ch[13]	Zyyy
+script for ch[14]	Hebr
+script for ch[15]	Hebr
+script for ch[16]	Hebr
+script for ch[17]	Arab
+script for ch[18]	Arab
+script for ch[19]	Zyyy
+script for ch[20]	Zinh
+script for ch[21]	Latn
+script for ch[22]	Latn
+script for ch[23]	Latn
+script for ch[24]	Zyyy
+script for ch[25]	Latn
+script for ch[26]	Latn
+script for ch[27]	Latn
+script for ch[28]	Latn
+script for ch[29]	Zyyy
+script for ch[30]	Zyyy
+script for ch[31]	Zyyy
+script for ch[32]	Arab
+script for ch[33]	Arab
+script for ch[34]	Arab
+script for ch[35]	Arab
+script for ch[36]	Arab
+
+After script detection:
+script for ch[0]	Arab
+script for ch[1]	Arab
+script for ch[2]	Arab
+script for ch[3]	Arab
+script for ch[4]	Hebr
+script for ch[5]	Hebr
+script for ch[6]	Hebr
+script for ch[7]	Hebr
+script for ch[8]	Hebr
+script for ch[9]	Arab
+script for ch[10]	Arab
+script for ch[11]	Arab
+script for ch[12]	Hebr
+script for ch[13]	Hebr
+script for ch[14]	Hebr
+script for ch[15]	Hebr
+script for ch[16]	Hebr
+script for ch[17]	Arab
+script for ch[18]	Arab
+script for ch[19]	Arab
+script for ch[20]	Arab
+script for ch[21]	Latn
+script for ch[22]	Latn
+script for ch[23]	Latn
+script for ch[24]	Latn
+script for ch[25]	Latn
+script for ch[26]	Latn
+script for ch[27]	Latn
+script for ch[28]	Latn
+script for ch[29]	Latn
+script for ch[30]	Arab
+script for ch[31]	Arab
+script for ch[32]	Arab
+script for ch[33]	Arab
+script for ch[34]	Arab
+script for ch[35]	Arab
+script for ch[36]	Arab
+
+Number of runs before script itemization: 3
+
+BiDi Runs:
+run[0]:	 start: 29	length: 8	level: 1
+run[1]:	 start: 21	length: 8	level: 2
+run[2]:	 start: 0	length: 21	level: 1
+
+Number of runs after script itemization: 8
+
+Final Runs:
+run[0]:	 start: 30	length: 7	direction: rtl	script: Arab	font: DejaVu Sans
+run[1]:	 start: 29	length: 1	direction: rtl	script: Latn	font: DejaVu Sans
+run[2]:	 start: 21	length: 8	direction: ltr	script: Latn	font: DejaVu Sans
+run[3]:	 start: 17	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
+run[4]:	 start: 12	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
+run[5]:	 start: 9	length: 3	direction: rtl	script: Arab	font: DejaVu Sans
+run[6]:	 start: 4	length: 5	direction: rtl	script: Hebr	font: DejaVu Sans
+run[7]:	 start: 0	length: 4	direction: rtl	script: Arab	font: DejaVu Sans
+
+Glyph information:
+glyph [35]	x_offset: 0	y_offset: 0	x_advance: 624	font: DejaVu Sans
+glyph [38]	x_offset: 0	y_offset: 0	x_advance: 618	font: DejaVu Sans
+glyph [40]	x_offset: 0	y_offset: 0	x_advance: 1266	font: DejaVu Sans
+glyph [42]	x_offset: 0	y_offset: 0	x_advance: 1130	font: DejaVu Sans
+glyph [50]	x_offset: 0	y_offset: 0	x_advance: 1097	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
+glyph [2]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
+glyph [4]	x_offset: 0	y_offset: 0	x_advance: 1260	font: DejaVu Sans
+glyph [9]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
+glyph [5]	x_offset: 0	y_offset: 0	x_advance: 1300	font: DejaVu Sans
+glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
+glyph [8]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
+glyph [7]	x_offset: 0	y_offset: 0	x_advance: 569	font: DejaVu Sans
+glyph [10]	x_offset: 0	y_offset: 0	x_advance: 1067	font: DejaVu Sans
+glyph [6]	x_offset: 0	y_offset: 0	x_advance: 1298	font: DejaVu Sans
+glyph [27]	x_offset: 0	y_offset: 0	x_advance: 0	font: DejaVu Sans
+glyph [3]	x_offset: 0	y_offset: 0	x_advance: 799	font: DejaVu Sans
+glyph [49]	x_offset: 0	y_offset: 0	x_advance: 1363	font: DejaVu Sans
+glyph [50]	x_offset: 10	y_offset: 0	x_advance: 1107	font: DejaVu Sans
+glyph [15]	x_offset: 10	y_offset: 0	x_advance: 1356	font: DejaVu Sans
+glyph [12]	x_offset: 10	y_offset: 0	x_advance: 468	font: DejaVu Sans
+glyph [14]	x_offset: 10	y_offset: 0	x_advance: 1166	font: DejaVu Sans
+glyph [1]	x_offset: 50	y_offset: 0	x_advance: 701	font: DejaVu Sans
+glyph [11]	x_offset: 10	y_offset: 0	x_advance: 1194	font: DejaVu Sans
+glyph [46]	x_offset: 10	y_offset: 0	x_advance: 1561	font: DejaVu Sans
+glyph [53]	x_offset: 10	y_offset: 0	x_advance: 1090	font: DejaVu Sans
+glyph [16]	x_offset: 10	y_offset: 0	x_advance: 579	font: DejaVu Sans
+glyph [15]	x_offset: 10	y_offset: 0	x_advance: 1356	font: DejaVu Sans
+glyph [12]	x_offset: 10	y_offset: 0	x_advance: 468	font: DejaVu Sans
+glyph [14]	x_offset: 10	y_offset: 0	x_advance: 1166	font: DejaVu Sans
+glyph [11]	x_offset: 10	y_offset: 0	x_advance: 1194	font: DejaVu Sans
+glyph [13]	x_offset: 10	y_offset: 0	x_advance: 1292	font: DejaVu Sans
+glyph [56]	x_offset: 10	y_offset: 0	x_advance: 1717	font: DejaVu Sans
+glyph [37]	x_offset: 10	y_offset: 0	x_advance: 580	font: DejaVu Sans
+glyph [42]	x_offset: 10	y_offset: 0	x_advance: 1140	font: DejaVu Sans
+glyph [44]	x_offset: 10	y_offset: 0	x_advance: 1232	font: DejaVu Sans
+
+UTF-32 clusters: 36 35 34 33 32 31 30 29 21 22 23 24 25 26 27 28 19 19 18 17 16 15 14 13 12 11 10 09 08 07 06 05 04 03 02 01 00
+UTF-8 clusters:  59 57 55 53 51 50 49 48 40 41 42 43 44 45 46 47 37 37 35 33 31 29 27 26 24 22 20 18 16 14 12 10 08 06 04 02 00

--- a/tests/letter-and-wordspacing.test
+++ b/tests/letter-and-wordspacing.test
@@ -233,12 +233,12 @@ glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [1]	x_offset: 0	y_offset: 0	x_advance: 651	font: DejaVu Sans
 glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1239	font: DejaVu Sans
-glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
-glyph [20]	x_offset: 10	y_offset: 0	x_advance: 999	font: DejaVu Sans
-glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1229	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1239	font: DejaVu Sans
+glyph [20]	x_offset: 0	y_offset: 0	x_advance: 989	font: DejaVu Sans
+glyph [0]	x_offset: 10	y_offset: 0	x_advance: 1239	font: DejaVu Sans
+glyph [0]	x_offset: 0	y_offset: 0	x_advance: 1229	font: DejaVu Sans
 
 UTF-32 clusters: 06 06 06 06 06 06 06 06 14 14 14 14 14 14 14 14 14 14 14 14 26 26 26 26 26 26 26 26 26 26 36 36 36 36 36 36 36 36 36 36 36 36 36 36 50 50 50 50 50 50 50 50 50 50 50 61 61 61 61 61 61 61 68 68 68 71 72 04 04 02 02 00 00
 UTF-8 clusters:  12 12 12 12 12 12 12 12 27 27 27 27 27 27 27 27 27 27 27 27 50 50 50 50 50 50 50 50 50 50 69 69 69 69 69 69 69 69 69 69 69 69 69 69 96 96 96 96 96 96 96 96 96 96 96 117 117 117 117 117 117 117 130 130 130 135 136 08 08 04 04 00 00

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -42,6 +42,7 @@ tests = [
   'invisible-glyph-space.test',
   'languages-sr-ru.test',
   'languages-sr.test',
+  'letter-and-wordspacing.test',
   'multi-fonts-1.test',
   'multi-fonts-2.test',
   'scripts-backward-ltr.test',

--- a/tests/raqm-test.c
+++ b/tests/raqm-test.c
@@ -40,6 +40,8 @@ static char *languages = NULL;
 static char *direction = NULL;
 static char *features = NULL;
 static char *require = NULL;
+static char *letterspacing = NULL;
+static char *wordspacing = NULL;
 static int cluster = -1;
 static int position = -1;
 static int invisible_glyph = 0;
@@ -100,6 +102,10 @@ parse_args (int argc, char **argv)
       direction = argv[++i];
     else if (strcmp (argv[i], "--font-features") == 0)
       features = argv[++i];
+    else if (strcmp (argv[i], "--letterspacing") == 0)
+      letterspacing = argv[++i];
+    else if (strcmp (argv[i], "--wordspacing") == 0)
+      wordspacing = argv[++i];
     else if (strcmp (argv[i], "--require") == 0)
       require = argv[++i];
     else if (strcmp (argv[i], "--cluster") == 0)
@@ -226,6 +232,32 @@ main (int argc, char **argv)
   {
     for (char *tok = strtok (features, ","); tok; tok = strtok (NULL, ","))
       assert (raqm_add_font_feature (rq, tok, -1));
+  }
+  
+  if (letterspacing)
+  {
+    for (char *tok = strtok (letterspacing, ","); tok; tok = strtok (NULL, ","))
+    {
+      int spacing = atoi (tok);
+      bool percentage = false;
+      int start, length;
+      start = atoi (strtok (NULL, ","));
+      length = atoi (strtok (NULL, ","));
+      assert (raqm_set_letter_spacing_range (rq, spacing, percentage, start, length));
+    }
+  }
+  
+  if (wordspacing)
+  {
+    for (char *tok = strtok (wordspacing, ","); tok; tok = strtok (NULL, ","))
+    {
+      int spacing = atoi (tok);
+      bool percentage = false;
+      int start, length;
+      start = atoi (strtok (NULL, ","));
+      length = atoi (strtok (NULL, ","));
+      assert (raqm_set_word_spacing_range (rq, spacing, percentage, start, length));
+    }
   }
 
   if (invisible_glyph)

--- a/tests/raqm-test.c
+++ b/tests/raqm-test.c
@@ -239,11 +239,10 @@ main (int argc, char **argv)
     for (char *tok = strtok (letterspacing, ","); tok; tok = strtok (NULL, ","))
     {
       int spacing = atoi (tok);
-      bool percentage = false;
       int start, length;
       start = atoi (strtok (NULL, ","));
       length = atoi (strtok (NULL, ","));
-      assert (raqm_set_letter_spacing_range (rq, spacing, percentage, start, length));
+      assert (raqm_set_letter_spacing_range (rq, spacing, start, length));
     }
   }
   
@@ -252,11 +251,10 @@ main (int argc, char **argv)
     for (char *tok = strtok (wordspacing, ","); tok; tok = strtok (NULL, ","))
     {
       int spacing = atoi (tok);
-      bool percentage = false;
       int start, length;
       start = atoi (strtok (NULL, ","));
       length = atoi (strtok (NULL, ","));
-      assert (raqm_set_word_spacing_range (rq, spacing, percentage, start, length));
+      assert (raqm_set_word_spacing_range (rq, spacing, start, length));
     }
   }
 


### PR DESCRIPTION
Implements letter and word spacing. This patch applies on top of #169 

![image](https://user-images.githubusercontent.com/1759191/166228615-f5bd187b-ee76-4dfa-95fe-d286bcd81a9f.png)

As discussed in #166 , LTR has the spacing added to the advance, RTL added to offset and advance, TTB spacing 'removed' from the advance because TTB advance is negative.

Fixes #166 