### PR TITLE
Fix resolved direction for all neutral text

### DIFF
--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1531,22 +1531,15 @@ _raqm_itemize (raqm_t *rq)
   bool ok = true;
 
 #ifdef RAQM_TESTING
-  switch (rq->base_dir)
-  {
-    case RAQM_DIRECTION_RTL:
-      RAQM_TEST ("Direction is: RTL\n\n");
-      break;
-    case RAQM_DIRECTION_LTR:
-      RAQM_TEST ("Direction is: LTR\n\n");
-      break;
-    case RAQM_DIRECTION_TTB:
-      RAQM_TEST ("Direction is: TTB\n\n");
-      break;
-    case RAQM_DIRECTION_DEFAULT:
-    default:
-      RAQM_TEST ("Direction is: DEFAULT\n\n");
-      break;
-  }
+  static char *dir_names[] = {
+    "DEFAULT",
+    "RTL",
+    "LTR",
+    "TTB"
+  };
+
+  assert (rq->base_dir < sizeof (dir_names));
+  RAQM_TEST ("Direction is: %s\n\n", dir_names[rq->base_dir]);
 #endif
 
   if (!_raqm_resolve_scripts (rq))
@@ -1578,6 +1571,9 @@ _raqm_itemize (raqm_t *rq)
   }
 
 #ifdef RAQM_TESTING
+  assert (rq->resolved_dir < sizeof (dir_names));
+  if (rq->base_dir == RAQM_DIRECTION_DEFAULT)
+    RAQM_TEST ("Resolved direction is: %s\n\n", dir_names[rq->resolved_dir]);
   RAQM_TEST ("Number of runs before script itemization: %zu\n\n", run_count);
 
   RAQM_TEST ("BiDi Runs:\n");

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -1348,10 +1348,10 @@ _raqm_bidi_itemize (raqm_t *rq, size_t *run_count)
   line = SBParagraphCreateLine (par, 0, par_len);
   *run_count = SBLineGetRunCount (line);
 
-  if (SBParagraphGetBaseLevel (par) == 0)
-    rq->resolved_dir = RAQM_DIRECTION_LTR;
-  else
+  if (SBParagraphGetBaseLevel (par) == 1)
     rq->resolved_dir = RAQM_DIRECTION_RTL;
+  else
+    rq->resolved_dir = RAQM_DIRECTION_LTR;
 
   runs = malloc (sizeof (_raqm_bidi_run) * (*run_count));
   if (runs)
@@ -1502,10 +1502,10 @@ _raqm_bidi_itemize (raqm_t *rq, size_t *run_count)
                                                    rq->text_len, &par_type,
                                                    levels);
 
-  if (par_type == FRIBIDI_PAR_LTR)
-    rq->resolved_dir = RAQM_DIRECTION_LTR;
-  else
+  if (par_type == FRIBIDI_PAR_RTL)
     rq->resolved_dir = RAQM_DIRECTION_RTL;
+  else
+    rq->resolved_dir = RAQM_DIRECTION_LTR;
 
   if (max_level == 0)
     goto done;

--- a/tests/buffer-flags-1.test
+++ b/tests/buffer-flags-1.test
@@ -15,6 +15,8 @@ script for ch[1]	Arab
 script for ch[2]	Arab
 script for ch[3]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/cursor-position-1.test
+++ b/tests/cursor-position-1.test
@@ -31,6 +31,8 @@ script for ch[9]	Arab
 script for ch[10]	Arab
 script for ch[11]	Arab
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/cursor-position-2.test
+++ b/tests/cursor-position-2.test
@@ -31,6 +31,8 @@ script for ch[9]	Arab
 script for ch[10]	Arab
 script for ch[11]	Arab
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/cursor-position-3.test
+++ b/tests/cursor-position-3.test
@@ -27,6 +27,8 @@ script for ch[7]	Latn
 script for ch[8]	Latn
 script for ch[9]	Latn
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/cursor-position-4.test
+++ b/tests/cursor-position-4.test
@@ -27,6 +27,8 @@ script for ch[7]	Latn
 script for ch[8]	Latn
 script for ch[9]	Latn
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/cursor-position-GB4.test
+++ b/tests/cursor-position-GB4.test
@@ -25,6 +25,8 @@ script for ch[6]	Latn
 script for ch[7]	Latn
 script for ch[8]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/cursor-position-GB5.test
+++ b/tests/cursor-position-GB5.test
@@ -25,6 +25,8 @@ script for ch[6]	Latn
 script for ch[7]	Latn
 script for ch[8]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/cursor-position-GB8a.test
+++ b/tests/cursor-position-GB8a.test
@@ -15,6 +15,8 @@ script for ch[1]	Zyyy
 script for ch[2]	Zyyy
 script for ch[3]	Zyyy
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/cursor-position-GB9.test
+++ b/tests/cursor-position-GB9.test
@@ -31,6 +31,8 @@ script for ch[9]	Arab
 script for ch[10]	Arab
 script for ch[11]	Arab
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/cursor-position-GB9a.test
+++ b/tests/cursor-position-GB9a.test
@@ -13,6 +13,8 @@ script for ch[0]	Deva
 script for ch[1]	Deva
 script for ch[2]	Deva
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/direction-neutral-1.test
+++ b/tests/direction-neutral-1.test
@@ -11,6 +11,8 @@ After script detection:
 script for ch[0]	Zyyy
 script for ch[1]	Zyyy
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/direction-neutral-1.test
+++ b/tests/direction-neutral-1.test
@@ -1,0 +1,29 @@
+fonts/sha1sum/bcb3b98eb67ece19b8b709f77143d91bcb3d95eb.ttf
+.!
+
+Direction is: DEFAULT
+
+Before script detection:
+script for ch[0]	Zyyy
+script for ch[1]	Zyyy
+
+After script detection:
+script for ch[0]	Zyyy
+script for ch[1]	Zyyy
+
+Number of runs before script itemization: 1
+
+BiDi Runs:
+run[0]:	 start: 0	length: 2	level: 0
+
+Number of runs after script itemization: 1
+
+Final Runs:
+run[0]:	 start: 0	length: 2	direction: ltr	script: Zyyy	font: Amiri
+
+Glyph information:
+glyph [17]	x_offset: 0	y_offset: 0	x_advance: 414	font: Amiri
+glyph [4]	x_offset: 0	y_offset: 0	x_advance: 482	font: Amiri
+
+UTF-32 clusters: 00 01
+UTF-8 clusters:  00 01

--- a/tests/features-arabic.test
+++ b/tests/features-arabic.test
@@ -33,6 +33,8 @@ script for ch[10]	Arab
 script for ch[11]	Arab
 script for ch[12]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/features-kerning.test
+++ b/tests/features-kerning.test
@@ -33,6 +33,8 @@ script for ch[10]	Latn
 script for ch[11]	Latn
 script for ch[12]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/features-ligature.test
+++ b/tests/features-ligature.test
@@ -37,6 +37,8 @@ script for ch[12]	Latn
 script for ch[13]	Latn
 script for ch[14]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -26,6 +26,7 @@ tests = [
   'direction-ltr-3.test',
   'direction-ltr-4.test',
   'direction-ltr-5.test',
+  'direction-neutral-1.test',
   'direction-rtl-1.test',
   'direction-rtl-2.test',
   'direction-rtl-3.test',

--- a/tests/multi-fonts-1.test
+++ b/tests/multi-fonts-1.test
@@ -49,6 +49,8 @@ script for ch[18]	Arab
 script for ch[19]	Arab
 script for ch[20]	Arab
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 2
 
 BiDi Runs:

--- a/tests/multi-fonts-2.test
+++ b/tests/multi-fonts-2.test
@@ -15,6 +15,8 @@ script for ch[1]	Arab
 script for ch[2]	Arab
 script for ch[3]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/scripts-backward.test
+++ b/tests/scripts-backward.test
@@ -77,6 +77,8 @@ script for ch[32]	Arab
 script for ch[33]	Arab
 script for ch[34]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 3
 
 BiDi Runs:

--- a/tests/scripts-common.test
+++ b/tests/scripts-common.test
@@ -19,6 +19,8 @@ script for ch[3]	Latn
 script for ch[4]	Latn
 script for ch[5]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/scripts-forward.test
+++ b/tests/scripts-forward.test
@@ -39,6 +39,8 @@ script for ch[13]	Cyrl
 script for ch[14]	Cyrl
 script for ch[15]	Cyrl
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/test-1.test
+++ b/tests/test-1.test
@@ -45,6 +45,8 @@ script for ch[16]	Arab
 script for ch[17]	Arab
 script for ch[18]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 3
 
 BiDi Runs:

--- a/tests/test-2.test
+++ b/tests/test-2.test
@@ -37,6 +37,8 @@ script for ch[12]	Arab
 script for ch[13]	Arab
 script for ch[14]	Arab
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 3
 
 BiDi Runs:

--- a/tests/test-3.test
+++ b/tests/test-3.test
@@ -63,6 +63,8 @@ script for ch[25]	Latn
 script for ch[26]	Latn
 script for ch[27]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 5
 
 BiDi Runs:

--- a/tests/test-4.test
+++ b/tests/test-4.test
@@ -43,6 +43,8 @@ script for ch[15]	Arab
 script for ch[16]	Arab
 script for ch[17]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/test-5.test
+++ b/tests/test-5.test
@@ -27,6 +27,8 @@ script for ch[7]	Latn
 script for ch[8]	Latn
 script for ch[9]	Latn
 
+Resolved direction is: LTR
+
 Number of runs before script itemization: 1
 
 BiDi Runs:

--- a/tests/xyoffset.test
+++ b/tests/xyoffset.test
@@ -13,6 +13,8 @@ script for ch[0]	Arab
 script for ch[1]	Arab
 script for ch[2]	Arab
 
+Resolved direction is: RTL
+
 Number of runs before script itemization: 1
 
 BiDi Runs:


### PR DESCRIPTION
FriBiDi will treat the text as LTR if no base direction is set, so make sure we set resolved dir the same way (i.e. treat `FRIBIDI_PAR_ON` as `FRIBIDI_PAR_LTR`). SheenBiDi will report LTR base level in this case, but I changed the code for consistency.