### PR TITLE
Update redirected URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,5 +81,5 @@ The following projects have patches to support complex text layout using Raqm:
 [1]: https://github.com/fribidi/fribidi
 [2]: https://github.com/Tehreer/SheenBidi
 [3]: https://github.com/harfbuzz/harfbuzz
-[4]: https://www.freetype.org
+[4]: https://freetype.org/
 [5]: https://www.gtk.org/gtk-doc


### PR DESCRIPTION
https://www.freetype.org has a 301 redirect to https://freetype.org/

Searching a quick way to demonstrate this, I found https://www.redirect-checker.org/index.php

![redirect](https://user-images.githubusercontent.com/3112309/211967412-11e31b0e-84a4-4d60-9349-ce096b953dbb.png)