### PR TITLE
meson.build: add darwin/macOS dylib versioning

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -15,10 +15,14 @@ endif
 
 configure_file(output: 'config.h', configuration: config_h)
 
+raqm_ver_major = raqm_version[0].to_int()
+raqm_ver_minor = raqm_version[1].to_int()
+raqm_ver_micro = raqm_version[2].to_int()
+
 version_h = configuration_data()
-version_h.set('RAQM_VERSION_MAJOR', raqm_version[0].to_int())
-version_h.set('RAQM_VERSION_MINOR', raqm_version[1].to_int())
-version_h.set('RAQM_VERSION_MICRO', raqm_version[2].to_int())
+version_h.set('RAQM_VERSION_MAJOR', raqm_ver_major)
+version_h.set('RAQM_VERSION_MINOR', raqm_ver_minor)
+version_h.set('RAQM_VERSION_MICRO', raqm_ver_micro)
 version_h.set('RAQM_VERSION', meson.project_version())
 
 configure_file(
@@ -32,11 +36,20 @@ configure_file(
 raqm_headers = files('raqm.h')
 install_headers(raqm_headers)
 
+# ABI compatibility version should be that used for last non-meson release, 0.7.2
+raqm_ver_compat = 701
+raqm_ver_current = raqm_ver_major * 10000 + raqm_ver_minor * 100 + raqm_ver_micro
+
+raqm_dylib_ver_compat = '@0@.0.0'.format(raqm_ver_compat)
+raqm_dylib_ver_current = '@0@.0.0'.format(raqm_ver_current)
+raqm_darwin_versions = [raqm_dylib_ver_compat, raqm_dylib_ver_current]
+
 libraqm = library(
     'raqm',
     'raqm.c',
     'raqm.h',
     version: meson.project_version(),
+    darwin_versions: raqm_darwin_versions,
     dependencies: deps,
     c_args: ['-DHAVE_CONFIG_H'],
     install: true,


### PR DESCRIPTION
When the project migrated to Meson, Darwin/macOS dylib versioning was lost. This restores that functionality, ensuring that dependent binaries aren't broken.

In terms of the dylib compatibility version, it's set to 0.7.1. I believe that matches with what was used for 0.7.2, when built via AutoTools.