### PR TITLE
Add support for SheenBidi 2.9

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,12 @@ if get_option('sheenbidi')
         'sheenbidi',
         fallback: ['sheenbidi', 'sheenbidi_dep'],
     )
+    if sheenbidi.version().version_compare('>= 2.9')
+        sheenbidi = declare_dependency(
+            compile_args: ['-DRAQM_SHEENBIDI_GT_2_9'],
+            dependencies: sheenbidi
+        )
+    endif
 else
     fribidi = dependency(
         'fribidi',

--- a/src/raqm.c
+++ b/src/raqm.c
@@ -30,7 +30,11 @@
 #include <string.h>
 
 #ifdef RAQM_SHEENBIDI
+#ifdef RAQM_SHEENBIDI_GT_2_9
+#include <SheenBidi/SheenBidi.h>
+#else
 #include <SheenBidi.h>
+#endif
 #else
 #include <fribidi.h>
 #endif


### PR DESCRIPTION
This release moved the main header from globally available to within a `SheenBidi` subdirectory.